### PR TITLE
[Do not merge] Adding claiming start timestamp as deployment parameter

### DIFF
--- a/src/contracts/CowProtocolVirtualToken.sol
+++ b/src/contracts/CowProtocolVirtualToken.sol
@@ -32,7 +32,8 @@ contract CowProtocolVirtualToken is
         uint256 gnoPrice,
         address wethToken,
         uint256 wethPrice,
-        address teamController
+        address teamController,
+        uint256 startTimestamp
     )
         NonTransferrableErc20(ERC20_NAME, ERC20_SYMBOL)
         Claiming(
@@ -45,7 +46,8 @@ contract CowProtocolVirtualToken is
             gnoPrice,
             wethToken,
             wethPrice,
-            teamController
+            teamController,
+            startTimestamp
         )
         MerkleDistributor(merkleRoot)
     // solhint-disable-next-line no-empty-blocks

--- a/src/contracts/mixins/Claiming.sol
+++ b/src/contracts/mixins/Claiming.sol
@@ -53,8 +53,8 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     /// for team claims.
     address public immutable teamController;
 
-    /// @dev Time at which this contract was deployed.
-    uint256 public immutable deploymentTimestamp;
+    /// @dev Time at which the claiming is started
+    uint256 public immutable startTimestamp;
 
     /// @dev Returns the amount of virtual tokens in existence, including those
     /// that have yet to be vested.
@@ -87,7 +87,8 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         uint256 _gnoPrice,
         address _wethToken,
         uint256 _wethPrice,
-        address _teamController
+        address _teamController,
+        uint256 _startTimestamp
     ) {
         cowToken = IERC20(_cowToken);
         communityFundsTarget = _communityFundsTarget;
@@ -100,8 +101,11 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         wethPrice = _wethPrice;
         teamController = _teamController;
 
-        // solhint-disable-next-line not-rely-on-time
-        deploymentTimestamp = block.timestamp;
+        if (_startTimestamp == 0) {
+            // solhint-disable-next-line not-rely-on-time
+            _startTimestamp = block.timestamp;
+        }
+        startTimestamp = _startTimestamp;
     }
 
     /// @dev Allows the decorated function only to be executed before the
@@ -111,7 +115,7 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     /// function reverts afterwards.
     modifier before(uint256 durationSinceDeployment) {
         // solhint-disable-next-line not-rely-on-time
-        if (block.timestamp > deploymentTimestamp + durationSinceDeployment) {
+        if (block.timestamp > startTimestamp + durationSinceDeployment) {
             revert ClaimingExpired();
         }
         _;

--- a/src/contracts/test/ClaimingTestInterface.sol
+++ b/src/contracts/test/ClaimingTestInterface.sol
@@ -18,7 +18,8 @@ contract ClaimingTestInterface is Claiming, NonTransferrableErc20 {
         uint256 _gnoPrice,
         address _wethToken,
         uint256 _wethPrice,
-        address _teamController
+        address _teamController,
+        uint256 _startTimestamp
     )
         Claiming(
             _cowToken,
@@ -30,7 +31,8 @@ contract ClaimingTestInterface is Claiming, NonTransferrableErc20 {
             _gnoPrice,
             _wethToken,
             _wethPrice,
-            _teamController
+            _teamController,
+            _startTimestamp
         )
         NonTransferrableErc20(ERC20_NAME, ERC20_SYMBOL)
     // solhint-disable-next-line no-empty-blocks

--- a/src/contracts/test/CowProtocolVirtualTokenTestInterface.sol
+++ b/src/contracts/test/CowProtocolVirtualTokenTestInterface.sol
@@ -15,7 +15,8 @@ contract CowProtocolVirtualTokenTestInterface is CowProtocolVirtualToken {
         uint256 gnoPrice,
         address wethToken,
         uint256 wethPrice,
-        address teamController
+        address teamController,
+        uint256 startTimestamp
     )
         CowProtocolVirtualToken(
             merkleRoot,
@@ -28,7 +29,8 @@ contract CowProtocolVirtualTokenTestInterface is CowProtocolVirtualToken {
             gnoPrice,
             wethToken,
             wethPrice,
-            teamController
+            teamController,
+            startTimestamp
         )
     // solhint-disable-next-line no-empty-blocks
     {

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -58,6 +58,7 @@ export interface VirtualTokenDeployParams {
   wethToken: string;
   wethPrice: BigNumberish;
   teamController: string;
+  startTimestamp: BigNumberish;
 }
 
 export enum ContractName {
@@ -82,6 +83,7 @@ export type ContructorInput = {
     string,
     BigNumber,
     string,
+    BigNumber,
   ];
 };
 
@@ -115,6 +117,7 @@ export function constructorInput<T extends ContractName>(
         wethToken,
         wethPrice,
         teamController,
+        startTimestamp,
       } = params as DeployParams[ContractName.VirtualToken];
       const result: ContructorInput[ContractName.VirtualToken] = [
         merkleRoot,
@@ -128,6 +131,7 @@ export function constructorInput<T extends ContractName>(
         wethToken,
         BigNumber.from(wethPrice),
         teamController,
+        BigNumber.from(startTimestamp),
       ];
       return result as ContructorInput[T];
     }

--- a/test/Claiming.test.ts
+++ b/test/Claiming.test.ts
@@ -44,7 +44,7 @@ describe("Claiming", function () {
   let gnoToken: MockContract;
   let wethToken: MockContract;
 
-  let deploymentTimestamp: number;
+  let startTimestamp: number;
 
   const [deployer, executor, ownsNoVirtualTokens, teamController] =
     waffle.provider.getWallets();
@@ -79,6 +79,7 @@ describe("Claiming", function () {
       gnoPrice,
       wethPrice,
       teamController: teamController.address,
+      startTimestamp: 0,
     };
 
     Claiming = await ethers.getContractFactory("ClaimingTestInterface");
@@ -87,7 +88,7 @@ describe("Claiming", function () {
         ...(await claimingConstructorInput(deploymentParams)),
       )
     ).connect(executor);
-    deploymentTimestamp = (await ethers.provider.getBlock("latest")).timestamp;
+    startTimestamp = (await ethers.provider.getBlock("latest")).timestamp;
   });
 
   it("sets the expected real token", async function () {
@@ -129,7 +130,7 @@ describe("Claiming", function () {
   });
 
   it("sets the expected deployment timestamp", async function () {
-    expect(await claiming.deploymentTimestamp()).to.equal(deploymentTimestamp);
+    expect(await claiming.startTimestamp()).to.equal(startTimestamp);
   });
 
   it("has zero starting total supply", async function () {
@@ -205,7 +206,7 @@ describe("Claiming", function () {
       });
 
       it("can be claimed until immediately before the deadline", async function () {
-        await setTime(deploymentTimestamp + FREE_CLAIM_EXPIRATION);
+        await setTime(startTimestamp + FREE_CLAIM_EXPIRATION);
         await expect(
           claiming.performClaimTest(
             ClaimType.Airdrop,
@@ -218,7 +219,7 @@ describe("Claiming", function () {
       });
 
       it("cannot be claimed after deadline", async function () {
-        await setTime(deploymentTimestamp + FREE_CLAIM_EXPIRATION + 1);
+        await setTime(startTimestamp + FREE_CLAIM_EXPIRATION + 1);
         await expect(
           claiming.performClaimTest(
             ClaimType.Airdrop,
@@ -320,7 +321,7 @@ describe("Claiming", function () {
       });
 
       it("can be claimed until immediately before the deadline", async function () {
-        await setTime(deploymentTimestamp + testParams.expiration);
+        await setTime(startTimestamp + testParams.expiration);
         await expect(
           claiming.performClaimTest(
             testParams.claimType,
@@ -333,7 +334,7 @@ describe("Claiming", function () {
       });
 
       it("cannot be claimed after deadline", async function () {
-        await setTime(deploymentTimestamp + testParams.expiration + 1);
+        await setTime(startTimestamp + testParams.expiration + 1);
         await expect(
           claiming.performClaimTest(
             testParams.claimType,

--- a/test/CowSwapVirtualToken.test.ts
+++ b/test/CowSwapVirtualToken.test.ts
@@ -64,6 +64,7 @@ describe("CowProtocolVirtualToken", () => {
       gnoPrice,
       wethPrice,
       teamController: teamController.address,
+      startTimestamp: 0,
     };
   });
 

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -36,6 +36,7 @@ describe("deployment", () => {
       wethToken: "0x" + "42".repeat(3).padEnd(38, "0") + "05",
       wethPrice: 31337,
       teamController: "0x" + "42".repeat(3).padEnd(38, "0") + "06",
+      startTimestamp: 0,
     };
   let currentSnapshot: unknown;
 


### PR DESCRIPTION
Adding claiming start timestamp as a deployment parameter. This enables us to better test our the front-ends, as we can deploy the contract into a certain state of the different airdrop phases.

---
We will not merge this, as we don't want to modify the contract after the audit.


### Test Plan
 Once the rinkeby deployment test script PR is ready, we can merge that one into this PR and test it properly.
