### PR TITLE
Rename ETH to native token

### DIFF
--- a/src/contracts/CowProtocolVirtualToken.sol
+++ b/src/contracts/CowProtocolVirtualToken.sol
@@ -30,8 +30,8 @@ contract CowProtocolVirtualToken is
         uint256 usdcPrice,
         address gnoToken,
         uint256 gnoPrice,
-        address wethToken,
-        uint256 wethPrice,
+        address wrappedNativeToken,
+        uint256 nativeTokenPrice,
         address teamController
     )
         NonTransferrableErc20(ERC20_NAME, ERC20_SYMBOL)
@@ -43,8 +43,8 @@ contract CowProtocolVirtualToken is
             usdcPrice,
             gnoToken,
             gnoPrice,
-            wethToken,
-            wethPrice,
+            wrappedNativeToken,
+            nativeTokenPrice,
             teamController
         )
         MerkleDistributor(merkleRoot)

--- a/src/contracts/interfaces/ClaimingInterface.sol
+++ b/src/contracts/interfaces/ClaimingInterface.sol
@@ -30,13 +30,13 @@ abstract contract ClaimingInterface {
     /// will receive the corresponding virtual tokens.
     /// @param claimedAmount The amount that the user decided to claim (after
     /// vesting if it applies).
-    /// @param sentEth The amount of ETH that the user sent along with the
-    /// transaction.
+    /// @param sentNativeTokens The amount of native tokens that the user sent
+    /// along with the transaction.
     function performClaim(
         ClaimType claimType,
         address payer,
         address claimant,
         uint256 claimedAmount,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) internal virtual;
 }

--- a/src/contracts/mixins/Claiming.sol
+++ b/src/contracts/mixins/Claiming.sol
@@ -26,9 +26,10 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     /// @dev Price numerator for the COW/GNO price. This is the number of GNO
     /// atoms required to obtain a full unit of virtual token from an option.
     uint256 public immutable gnoPrice;
-    /// @dev Price numerator for the COW/WETH price. This is the number of WETH
-    /// wei required to obtain a full unit of virtual token from an option.
-    uint256 public immutable wethPrice;
+    /// @dev Price numerator for the COW/native-token price. This is the number
+    /// of native token wei required to obtain a full unit of virtual token from
+    /// an option.
+    uint256 public immutable nativeTokenPrice;
 
     /// @dev The proceeds from selling options to the community will be sent to,
     /// this address.
@@ -44,9 +45,10 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     /// @dev Address of the GNO token. It is a form of payment for users who
     /// claim the options derived from holding GNO.
     IERC20 public immutable gnoToken;
-    /// @dev Address of the WETH token. It is a form of payment for users who
-    /// claim the options derived from being users of the CoW Protocol.
-    IERC20 public immutable wethToken;
+    /// @dev Address of the wrapped native token. It is a form of payment for
+    /// users who claim the options derived from being users of the CoW
+    /// Protocol.
+    IERC20 public immutable wrappedNativeToken;
 
     /// @dev Address representing the CoW Protocol/CowSwap team. It is the only
     /// address that is allowed to stop the vesting of a claim, and exclusively
@@ -70,12 +72,12 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     /// @dev Error presented to anyone but the team controller to stop a
     /// cancelable vesting position (i.e., only team vesting).
     error OnlyTeamController();
-    /// @dev Error resulting from sending an incorrect amount of eth to the
+    /// @dev Error resulting from sending an incorrect amount of native to the
     /// contract.
-    error InvalidEthAmount();
-    /// @dev Error resulting from sending ETH for a claim that cannot be
-    /// redeemed with ETH.
-    error CannotSendEth();
+    error InvalidNativeTokenAmount();
+    /// @dev Error resulting from sending native tokens for a claim that cannot
+    /// be redeemed with native tokens.
+    error CannotSendNativeToken();
 
     constructor(
         address _cowToken,
@@ -85,8 +87,8 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         uint256 _usdcPrice,
         address _gnoToken,
         uint256 _gnoPrice,
-        address _wethToken,
-        uint256 _wethPrice,
+        address _wrappedNativeToken,
+        uint256 _nativeTokenPrice,
         address _teamController
     ) {
         cowToken = IERC20(_cowToken);
@@ -96,8 +98,8 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         usdcPrice = _usdcPrice;
         gnoToken = IERC20(_gnoToken);
         gnoPrice = _gnoPrice;
-        wethToken = IERC20(_wethToken);
-        wethPrice = _wethPrice;
+        wrappedNativeToken = IERC20(_wrappedNativeToken);
+        nativeTokenPrice = _nativeTokenPrice;
         teamController = _teamController;
 
         // solhint-disable-next-line not-rely-on-time
@@ -131,21 +133,21 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         address payer,
         address claimant,
         uint256 amount,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) internal override {
         if (claimType == ClaimType.Airdrop) {
-            claimAirdrop(claimant, amount, sentEth);
+            claimAirdrop(claimant, amount, sentNativeTokens);
         } else if (claimType == ClaimType.GnoOption) {
-            claimGnoOption(claimant, amount, payer, sentEth);
+            claimGnoOption(claimant, amount, payer, sentNativeTokens);
         } else if (claimType == ClaimType.UserOption) {
-            claimUserOption(claimant, amount, payer, sentEth);
+            claimUserOption(claimant, amount, payer, sentNativeTokens);
         } else if (claimType == ClaimType.Investor) {
-            claimInvestor(claimant, amount, payer, sentEth);
+            claimInvestor(claimant, amount, payer, sentNativeTokens);
         } else if (claimType == ClaimType.Team) {
-            claimTeam(claimant, amount, sentEth);
+            claimTeam(claimant, amount, sentNativeTokens);
         } else {
             // claimType == ClaimType.Advisor
-            claimAdvisor(claimant, amount, sentEth);
+            claimAdvisor(claimant, amount, sentNativeTokens);
         }
 
         // Each claiming operation results in the creation of `amount` virtual
@@ -168,10 +170,10 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     function claimAirdrop(
         address account,
         uint256 amount,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private before(6 weeks) {
-        if (sentEth != 0) {
-            revert CannotSendEth();
+        if (sentNativeTokens != 0) {
+            revert CannotSendNativeToken();
         }
         instantlySwappableBalance[account] += amount;
     }
@@ -184,16 +186,16 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         address account,
         uint256 amount,
         address payer,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private before(2 weeks) {
-        if (sentEth != 0) {
-            revert CannotSendEth();
+        if (sentNativeTokens != 0) {
+            revert CannotSendNativeToken();
         }
         collectPayment(gnoToken, gnoPrice, payer, communityFundsTarget, amount);
         addVesting(account, amount, false);
     }
 
-    /// @dev Claims an Eth-based option for the user.
+    /// @dev Claims a native-token-based option for the user.
     /// @param account The user for which the claim is performed.
     /// @param amount The full amount claimed by the user after vesting.
     /// @param payer The address that pays the amount required by the claim.
@@ -201,14 +203,18 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         address account,
         uint256 amount,
         address payer,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private before(2 weeks) {
-        if (sentEth != 0) {
-            collectEthPayment(communityFundsTarget, amount, sentEth);
+        if (sentNativeTokens != 0) {
+            collectNativeTokenPayment(
+                communityFundsTarget,
+                amount,
+                sentNativeTokens
+            );
         } else {
             collectPayment(
-                wethToken,
-                wethPrice,
+                wrappedNativeToken,
+                nativeTokenPrice,
                 payer,
                 communityFundsTarget,
                 amount
@@ -225,10 +231,10 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         address account,
         uint256 amount,
         address payer,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private before(2 weeks) {
-        if (sentEth != 0) {
-            revert CannotSendEth();
+        if (sentNativeTokens != 0) {
+            revert CannotSendNativeToken();
         }
         collectPayment(
             usdcToken,
@@ -247,10 +253,10 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     function claimTeam(
         address account,
         uint256 amount,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private before(6 weeks) {
-        if (sentEth != 0) {
-            revert CannotSendEth();
+        if (sentNativeTokens != 0) {
+            revert CannotSendNativeToken();
         }
         addVesting(account, amount, true);
     }
@@ -262,10 +268,10 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
     function claimAdvisor(
         address account,
         uint256 amount,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private before(6 weeks) {
-        if (sentEth != 0) {
-            revert CannotSendEth();
+        if (sentNativeTokens != 0) {
+            revert CannotSendNativeToken();
         }
         addVesting(account, amount, false);
     }
@@ -289,21 +295,25 @@ abstract contract Claiming is ClaimingInterface, VestingInterface, IERC20 {
         token.safeTransferFrom(from, to, tokenEquivalent);
     }
 
-    /// @dev Transfers eth from this contract to the target, assuming that the
-    /// amount of ETH sent coincides with the expected amount of ETH. This
-    /// amount is based on the price of WETH and amount of COW bought.
+    /// @dev Transfers native tokens from this contract to the target, assuming
+    /// that the amount of native tokens sent coincides with the expected amount
+    /// of native tokens. This amount is based on the price of the native token
+    /// and amount of COW bought.
     /// @param to The address to which to send the funds.
     /// @param amount The amount of COW atoms that will be paid for.
-    function collectEthPayment(
+    function collectNativeTokenPayment(
         address payable to,
         uint256 amount,
-        uint256 sentEth
+        uint256 sentNativeTokens
     ) private {
-        uint256 ethEquivalent = convertCowAmountAtPrice(amount, wethPrice);
-        if (sentEth != ethEquivalent) {
-            revert InvalidEthAmount();
+        uint256 nativeTokenEquivalent = convertCowAmountAtPrice(
+            amount,
+            nativeTokenPrice
+        );
+        if (sentNativeTokens != nativeTokenEquivalent) {
+            revert InvalidNativeTokenAmount();
         }
-        to.transfer(ethEquivalent);
+        to.transfer(nativeTokenEquivalent);
     }
 
     /// @dev Converts input amount in COW token atoms to an amount in token

--- a/src/contracts/test/ClaimingTestInterface.sol
+++ b/src/contracts/test/ClaimingTestInterface.sol
@@ -16,8 +16,8 @@ contract ClaimingTestInterface is Claiming, NonTransferrableErc20 {
         uint256 _usdcPrice,
         address _gnoToken,
         uint256 _gnoPrice,
-        address _wethToken,
-        uint256 _wethPrice,
+        address _wrappedNativeToken,
+        uint256 _nativeTokenPrice,
         address _teamController
     )
         Claiming(
@@ -28,8 +28,8 @@ contract ClaimingTestInterface is Claiming, NonTransferrableErc20 {
             _usdcPrice,
             _gnoToken,
             _gnoPrice,
-            _wethToken,
-            _wethPrice,
+            _wrappedNativeToken,
+            _nativeTokenPrice,
             _teamController
         )
         NonTransferrableErc20(ERC20_NAME, ERC20_SYMBOL)
@@ -43,9 +43,9 @@ contract ClaimingTestInterface is Claiming, NonTransferrableErc20 {
         address payer,
         address account,
         uint256 amount,
-        uint256 ethAmount
+        uint256 nativeTokenAmount
     ) public payable {
-        performClaim(claimType, payer, account, amount, ethAmount);
+        performClaim(claimType, payer, account, amount, nativeTokenAmount);
     }
 
     function addInstantlySwappableTokens(address user, uint256 amount) public {

--- a/src/contracts/test/CowProtocolVirtualTokenTestInterface.sol
+++ b/src/contracts/test/CowProtocolVirtualTokenTestInterface.sol
@@ -13,8 +13,8 @@ contract CowProtocolVirtualTokenTestInterface is CowProtocolVirtualToken {
         uint256 usdcPrice,
         address gnoToken,
         uint256 gnoPrice,
-        address wethToken,
-        uint256 wethPrice,
+        address wrappedNativeToken,
+        uint256 nativeTokenPrice,
         address teamController
     )
         CowProtocolVirtualToken(
@@ -26,8 +26,8 @@ contract CowProtocolVirtualTokenTestInterface is CowProtocolVirtualToken {
             usdcPrice,
             gnoToken,
             gnoPrice,
-            wethToken,
-            wethPrice,
+            wrappedNativeToken,
+            nativeTokenPrice,
             teamController
         )
     // solhint-disable-next-line no-empty-blocks

--- a/src/contracts/test/MerkleDistributorTestInterface.sol
+++ b/src/contracts/test/MerkleDistributorTestInterface.sol
@@ -13,7 +13,7 @@ contract MerkleDistributorTestInterface is MerkleDistributor {
         address payer,
         address claimant,
         uint256 amount,
-        uint256 ethAmount
+        uint256 nativeTokenAmount
     );
 
     function performClaim(
@@ -21,9 +21,15 @@ contract MerkleDistributorTestInterface is MerkleDistributor {
         address payer,
         address claimant,
         uint256 claimableAmount,
-        uint256 ethAmount
+        uint256 nativeTokenAmount
     ) internal override {
-        emit HasClaimed(claimType, payer, claimant, claimableAmount, ethAmount);
+        emit HasClaimed(
+            claimType,
+            payer,
+            claimant,
+            claimableAmount,
+            nativeTokenAmount
+        );
     }
 
     function claimName(ClaimType claim) public pure returns (string memory) {

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -55,8 +55,8 @@ export interface VirtualTokenDeployParams {
   usdcPrice: BigNumberish;
   gnoToken: string;
   gnoPrice: BigNumberish;
-  wethToken: string;
-  wethPrice: BigNumberish;
+  wrappedNativeToken: string;
+  nativeTokenPrice: BigNumberish;
   teamController: string;
 }
 
@@ -112,8 +112,8 @@ export function constructorInput<T extends ContractName>(
         usdcPrice,
         gnoToken,
         gnoPrice,
-        wethToken,
-        wethPrice,
+        wrappedNativeToken,
+        nativeTokenPrice,
         teamController,
       } = params as DeployParams[ContractName.VirtualToken];
       const result: ContructorInput[ContractName.VirtualToken] = [
@@ -125,8 +125,8 @@ export function constructorInput<T extends ContractName>(
         BigNumber.from(usdcPrice),
         gnoToken,
         BigNumber.from(gnoPrice),
-        wethToken,
-        BigNumber.from(wethPrice),
+        wrappedNativeToken,
+        BigNumber.from(nativeTokenPrice),
         teamController,
       ];
       return result as ContructorInput[T];

--- a/test/Claiming.test.ts
+++ b/test/Claiming.test.ts
@@ -42,7 +42,7 @@ describe("Claiming", function () {
   let realToken: MockContract;
   let usdcToken: MockContract;
   let gnoToken: MockContract;
-  let wethToken: MockContract;
+  let wrappedNativeToken: MockContract;
 
   let deploymentTimestamp: number;
 
@@ -59,25 +59,25 @@ describe("Claiming", function () {
   // - 1 WETH = 4000 USDC
   const usdcPrice = utils.parseUnits("0.1", 6);
   const gnoPrice = utils.parseUnits("1", 18).div(4000);
-  const wethPrice = utils.parseUnits("1", 18).div(40000);
+  const nativeTokenPrice = utils.parseUnits("1", 18).div(40000);
   let deploymentParams: ClaimingDeploymentParams;
 
   beforeEach(async function () {
     realToken = await waffle.deployMockContract(deployer, IERC20.abi);
     usdcToken = await waffle.deployMockContract(deployer, IERC20.abi);
     gnoToken = await waffle.deployMockContract(deployer, IERC20.abi);
-    wethToken = await waffle.deployMockContract(deployer, IERC20.abi);
+    wrappedNativeToken = await waffle.deployMockContract(deployer, IERC20.abi);
 
     deploymentParams = {
       realToken: realToken.address,
       gnoToken: gnoToken.address,
       usdcToken: usdcToken.address,
-      wethToken: wethToken.address,
+      wrappedNativeToken: wrappedNativeToken.address,
       communityFundsTarget,
       investorFundsTarget,
       usdcPrice,
       gnoPrice,
-      wethPrice,
+      nativeTokenPrice,
       teamController: teamController.address,
     };
 
@@ -116,12 +116,14 @@ describe("Claiming", function () {
     expect(await claiming.gnoPrice()).to.equal(gnoPrice);
   });
 
-  it("sets the expected WETH token", async function () {
-    expect(await claiming.wethToken()).to.equal(wethToken.address);
+  it("sets the expected wrapped native token", async function () {
+    expect(await claiming.wrappedNativeToken()).to.equal(
+      wrappedNativeToken.address,
+    );
   });
 
-  it("sets the expected WETH price", async function () {
-    expect(await claiming.wethPrice()).to.equal(wethPrice);
+  it("sets the expected native token price", async function () {
+    expect(await claiming.nativeTokenPrice()).to.equal(nativeTokenPrice);
   });
 
   it("sets the expected team controller", async function () {
@@ -239,7 +241,7 @@ describe("Claiming", function () {
             claimedAmount,
             constants.One,
           ),
-        ).to.be.revertedWith(customError("CannotSendEth"));
+        ).to.be.revertedWith(customError("CannotSendNativeToken"));
       });
     });
 
@@ -359,7 +361,7 @@ describe("Claiming", function () {
               claimedAmount,
               constants.One,
             ),
-          ).to.be.revertedWith(customError("CannotSendEth"));
+          ).to.be.revertedWith(customError("CannotSendNativeToken"));
         });
       });
     }
@@ -369,7 +371,7 @@ describe("Claiming", function () {
       paymentTokenName: string;
       price: BigNumber;
       fundsTarget: "communityFunds" | "investorFunds";
-      acceptsEthAt?: BigNumber;
+      acceptsNativeTokensAt?: BigNumber;
     }
     function target(fundsTarget: "communityFunds" | "investorFunds"): string {
       switch (fundsTarget) {
@@ -388,7 +390,7 @@ describe("Claiming", function () {
         case "GNO":
           return gnoToken;
         case "WETH":
-          return wethToken;
+          return wrappedNativeToken;
         default:
           throw new Error("Invalid token");
       }
@@ -449,9 +451,9 @@ describe("Claiming", function () {
           ).to.be.revertedWith("failed transfer");
         });
 
-        if (testParams.acceptsEthAt !== undefined) {
+        if (testParams.acceptsNativeTokensAt !== undefined) {
           const ethProceeds = amount
-            .mul(testParams.acceptsEthAt)
+            .mul(testParams.acceptsNativeTokensAt)
             .div(priceDenominator);
 
           describe("can use ETH for claiming", async function () {
@@ -476,7 +478,7 @@ describe("Claiming", function () {
                 amount,
                 ethProceeds.sub(1),
               ),
-            ).to.be.revertedWith(customError("InvalidEthAmount"));
+            ).to.be.revertedWith(customError("InvalidNativeTokenAmount"));
           });
 
           it("reverts if sending too much ETH", async function () {
@@ -488,7 +490,7 @@ describe("Claiming", function () {
                 amount,
                 ethProceeds.add(1),
               ),
-            ).to.be.revertedWith(customError("InvalidEthAmount"));
+            ).to.be.revertedWith(customError("InvalidNativeTokenAmount"));
           });
 
           it("reverts if ETH transfer fails", async function () {
@@ -523,7 +525,9 @@ describe("Claiming", function () {
                 amount,
                 ethProceeds,
               ),
-            ).to.be.revertedWith(RevertMessage.ContractCannotReceiveEth);
+            ).to.be.revertedWith(
+              RevertMessage.ContractCannotReceiveNativeTokens,
+            );
           });
         } else {
           it("reverts if sending ETH when claiming", async function () {
@@ -535,7 +539,7 @@ describe("Claiming", function () {
                 amount,
                 constants.One,
               ),
-            ).to.be.revertedWith(customError("CannotSendEth"));
+            ).to.be.revertedWith(customError("CannotSendNativeToken"));
           });
         }
 
@@ -569,8 +573,8 @@ describe("Claiming", function () {
       isCancelable: false,
       expiration: PAID_OPTION_EXPIRATION,
       paymentTokenName: "WETH",
-      price: wethPrice,
-      acceptsEthAt: wethPrice,
+      price: nativeTokenPrice,
+      acceptsNativeTokensAt: nativeTokenPrice,
       fundsTarget: "communityFunds",
     });
 

--- a/test/CowSwapVirtualToken.test.ts
+++ b/test/CowSwapVirtualToken.test.ts
@@ -29,7 +29,7 @@ describe("CowProtocolVirtualToken", () => {
   let realToken: MockContract;
   let usdcToken: MockContract;
   let gnoToken: MockContract;
-  let wethToken: MockContract;
+  let wrappedNativeToken: MockContract;
   let CowProtocolVirtualToken: ContractFactory;
 
   const [deployer, executor, user, teamController, teamMember] =
@@ -40,14 +40,14 @@ describe("CowProtocolVirtualToken", () => {
   const investorFundsTarget = "0x" + "42".repeat(3).padEnd(38, "0") + "02";
   const usdcPrice = 31337;
   const gnoPrice = 42;
-  const wethPrice = 1337;
+  const nativeTokenPrice = 1337;
   let deploymentParams: VirtualTokenDeployParams;
 
   beforeEach(async () => {
     realToken = await waffle.deployMockContract(deployer, IERC20.abi);
     usdcToken = await waffle.deployMockContract(deployer, IERC20.abi);
     gnoToken = await waffle.deployMockContract(deployer, IERC20.abi);
-    wethToken = await waffle.deployMockContract(deployer, IERC20.abi);
+    wrappedNativeToken = await waffle.deployMockContract(deployer, IERC20.abi);
 
     CowProtocolVirtualToken = (
       await ethers.getContractFactory(ContractName.VirtualToken)
@@ -58,11 +58,11 @@ describe("CowProtocolVirtualToken", () => {
       investorFundsTarget,
       gnoToken: gnoToken.address,
       usdcToken: usdcToken.address,
-      wethToken: wethToken.address,
+      wrappedNativeToken: wrappedNativeToken.address,
       communityFundsTarget,
       usdcPrice,
       gnoPrice,
-      wethPrice,
+      nativeTokenPrice,
       teamController: teamController.address,
     };
   });
@@ -114,12 +114,14 @@ describe("CowProtocolVirtualToken", () => {
       expect(await token.gnoPrice()).to.equal(gnoPrice);
     });
 
-    it("sets the expected WETH token", async function () {
-      expect(await token.wethToken()).to.equal(wethToken.address);
+    it("sets the expected wrapped native token", async function () {
+      expect(await token.wrappedNativeToken()).to.equal(
+        wrappedNativeToken.address,
+      );
     });
 
-    it("sets the expected WETH price", async function () {
-      expect(await token.wethPrice()).to.equal(wethPrice);
+    it("sets the expected native token price", async function () {
+      expect(await token.nativeTokenPrice()).to.equal(nativeTokenPrice);
     });
 
     it("sets the expected team controller", async function () {
@@ -392,7 +394,7 @@ describe("CowProtocolVirtualToken", () => {
         await realToken.mock.transfer.returns(true);
         await usdcToken.mock.transferFrom.returns(true);
         await gnoToken.mock.transferFrom.returns(true);
-        await wethToken.mock.transferFrom.returns(true);
+        await wrappedNativeToken.mock.transferFrom.returns(true);
       });
 
       function testClaim(provenClaim: ProvenClaim) {

--- a/test/MerkleDistributor.test.ts
+++ b/test/MerkleDistributor.test.ts
@@ -404,7 +404,7 @@ describe("MerkleDistributor", () => {
       expect(await distributor.isClaimed(executableFullClaim.index)).to.be.true;
     });
 
-    it("allows using eth to claim", async function () {
+    it("allows using native tokens to claim", async function () {
       const {
         merkleRoot,
         claims: [provenClaim1, provenClaim2, provenClaimNoEth],
@@ -463,7 +463,7 @@ describe("MerkleDistributor", () => {
       expect(await distributor.isClaimed(executedClaimNoEth.index)).to.be.true;
     });
 
-    it("reverts if the amount of eth sent is not correct", async function () {
+    it("reverts if the amount of native tokens sent is not correct", async function () {
       const {
         merkleRoot,
         claims: [provenClaim1, provenClaim2],
@@ -488,7 +488,7 @@ describe("MerkleDistributor", () => {
           ]),
           { value: value1.add(value2).sub(1) },
         ),
-      ).to.be.revertedWith(customError("InvalidEthValue"));
+      ).to.be.revertedWith(customError("InvalidNativeTokenValue"));
 
       await expect(
         distributor.claimMany(
@@ -504,7 +504,7 @@ describe("MerkleDistributor", () => {
           ]),
           { value: value1.add(value2).add(1) },
         ),
-      ).to.be.revertedWith(customError("InvalidEthValue"));
+      ).to.be.revertedWith(customError("InvalidNativeTokenValue"));
     });
 
     describe("if input arrays have different length", function () {

--- a/test/custom-errors.ts
+++ b/test/custom-errors.ts
@@ -12,5 +12,5 @@ export enum RevertMessage {
   ArrayIndexOutOfBound = "reverted with panic code 0x32 (Array accessed at an out-of-bounds or negative index)",
   OverOrUnderflow = "reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)",
   UninitializedMock = "Mock on the method is not initialized",
-  ContractCannotReceiveEth = "Transaction reverted: function selector was not recognized and there's no fallback nor receive function",
+  ContractCannotReceiveNativeTokens = "Transaction reverted: function selector was not recognized and there's no fallback nor receive function",
 }

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -33,8 +33,8 @@ describe("deployment", () => {
       usdcPrice: 42,
       gnoToken: "0x" + "42".repeat(3).padEnd(38, "0") + "04",
       gnoPrice: 1337,
-      wethToken: "0x" + "42".repeat(3).padEnd(38, "0") + "05",
-      wethPrice: 31337,
+      wrappedNativeToken: "0x" + "42".repeat(3).padEnd(38, "0") + "05",
+      nativeTokenPrice: 31337,
       teamController: "0x" + "42".repeat(3).padEnd(38, "0") + "06",
     };
   let currentSnapshot: unknown;
@@ -224,15 +224,15 @@ describe("deployment", () => {
         );
       });
 
-      it("wethToken", async function () {
-        expect(await virtualToken.wethToken()).to.equal(
-          virtualTokenDeployParams.wethToken,
+      it("wrappedNativeToken", async function () {
+        expect(await virtualToken.wrappedNativeToken()).to.equal(
+          virtualTokenDeployParams.wrappedNativeToken,
         );
       });
 
-      it("wethPrice", async function () {
-        expect(await virtualToken.wethPrice()).to.equal(
-          virtualTokenDeployParams.wethPrice,
+      it("nativeTokenPrice", async function () {
+        expect(await virtualToken.nativeTokenPrice()).to.equal(
+          virtualTokenDeployParams.nativeTokenPrice,
         );
       });
 


### PR DESCRIPTION
Replaces occurrences of ETH with "native token". Originally this contract was supposed to be deployed only on the ethereum chain, but it will also be deployed on xDai/Gnosis Chain.

No changes to the contract logic were introduced. However, the ABI of the contract will change, which means we will need to deploy a new version of the NPM package. The version bump will be done in another PR.

I left some occurrences of "ETH" in the tests because I thought it was easier to read.

### Test Plan

Existing unit tests.