### PR TITLE
Add script to generate Rinkeby deployment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+export PK='insert you private key here'
+export INFURA_KEY='insert your Infura key here'
+# Alternatively:
+#export NODE_URL='https://insert your node URL here'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 coverage/
 deployments/*/solcInputs
 deployments/localhost/
+output/
 lib/
 node_modules/
 coverage.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage.json
 yarn-error.log
 *.tgz
 .mocharc.json
+.env

--- a/README.md
+++ b/README.md
@@ -67,4 +67,22 @@ yarn bench:code-size
 ### Deploying Contracts
 
 The contracts are expected to be deployed by the Gnosis DAO using the Zodiac module.
-A script to create this transaction will be included in this repo.
+
+#### Test deployment
+
+A script that can be used to create a live test deployment of the token contract on the supported networks.
+It generates private keys for each user participating in the auctions based on a mnemonic parameter.
+Any valid combination of claims can be found among the generated addresses.
+
+The script also deploys all administration Gnosis Safe, for example the DAOs and the funds targets. By default, they will be owned by the deployer address.
+
+Here is an example of how to run a deployment:
+```
+export INFURA_KEY='insert your Infura key here'
+export PK='insert you private key here'
+npx hardhat test-deployment --network rinkeby --mnemonic "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+```
+
+The output files can be found in the `output/` folder, which include the addresses of the deployed Gnosis Safes.
+
+More advanced options can be listed by running `npx hardhat test-deployment --help`.

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,2 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export function setupTasks(): void {}
+import { setupTestDeploymentTask } from "./test-deployment";
+
+export function setupTasks(): void {
+  setupTestDeploymentTask();
+}

--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -43,7 +43,7 @@ const defaultTokens = {
 
 const defaultArgs = {
   userCount: 1000,
-  totalSupply: (10 ** (3 * 4)).toString(),
+  totalSupply: (10n ** (3n * 4n)).toString(),
   usdcPerCow: "0.15",
   usdcPerGno: "400",
   usdcPerWeth: "4000",

--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -1,0 +1,382 @@
+import { promises as fs } from "fs";
+
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20Metadata.json";
+import { expect } from "chai";
+import { BigNumber, Contract, utils, Wallet } from "ethers";
+import { id } from "ethers/lib/utils";
+import { task, types } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import {
+  metadata,
+  prepareSafeDeployment,
+  RealTokenDeployParams,
+  VirtualTokenDeployParams,
+  Claim,
+  ClaimType,
+  allClaimTypes,
+  computeProofs,
+} from "../ts";
+import { splitClaimsAndSaveToFolder } from "../ts/split";
+
+import {
+  SupportedChainId,
+  isChainIdSupported,
+  deployWithOwners,
+  MultiSendDeployment,
+  execSafeTransaction,
+} from "./ts/safe";
+
+const OUTPUT_FOLDER = "./output";
+
+const defaultTokens = {
+  usdc: {
+    "4": "0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b",
+  },
+  weth: {
+    "4": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+  },
+  gno: {
+    "4": "0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c",
+  },
+} as const;
+
+const defaultArgs = {
+  userCount: 1000,
+  totalSupply: (10 ** (3 * 4)).toString(),
+  usdcPerCow: "0.15",
+  usdcPerGno: "400",
+  usdcPerWeth: "4000",
+} as const;
+interface DeployTaskArgs {
+  mnemonic: string;
+  userCount?: number;
+  totalSupply?: string;
+  usdcToken?: string;
+  usdcPerCow?: string;
+  gnoToken?: string;
+  usdcPerGno?: string;
+  wethToken?: string;
+  usdcPerWeth?: string;
+}
+interface CleanArgs {
+  mnemonic: string;
+  userCount: number;
+  totalSupply: BigNumber;
+  usdc: Token;
+  usdcPerCow: BigNumber;
+  gno: Token;
+  usdcPerGno: BigNumber;
+  weth: Token;
+  usdcPerWeth: BigNumber;
+  chainId: SupportedChainId;
+}
+
+interface Token {
+  decimals: number;
+  instance: Contract;
+}
+
+async function parseArgs(
+  args: DeployTaskArgs,
+  { ethers }: HardhatRuntimeEnvironment,
+): Promise<CleanArgs> {
+  const chainId = (await ethers.provider.getNetwork()).chainId.toString();
+
+  if (!isChainIdSupported(chainId)) {
+    throw new Error(`Chain id ${chainId} not supported by the Gnosis Safe`);
+  }
+
+  function defaultIfUnset<Key extends keyof typeof defaultTokens>(
+    address: string | undefined,
+    token: Key,
+  ): string {
+    const defaultByChainId: Record<string, string> = defaultTokens[token];
+    if (
+      address === undefined &&
+      !Object.keys(defaultByChainId).includes(chainId)
+    ) {
+      throw new Error(
+        `Chain id ${chainId} does not have a default address for ${token}`,
+      );
+    }
+    const defaultAddress =
+      defaultByChainId[chainId as keyof typeof defaultByChainId];
+    return address ?? defaultAddress;
+  }
+  async function getToken(address: string): Promise<Token> {
+    const instance = new Contract(address, IERC20.abi).connect(ethers.provider);
+    const decimals = await instance.decimals();
+    if (typeof decimals !== "number") {
+      throw new Error(
+        `Invalid number of decimals for token at address ${address}`,
+      );
+    }
+    return {
+      instance,
+      decimals,
+    };
+  }
+  const [usdc, gno, weth] = await Promise.all([
+    getToken(defaultIfUnset(args.usdcToken, "usdc")),
+    getToken(defaultIfUnset(args.gnoToken, "gno")),
+    getToken(defaultIfUnset(args.wethToken, "weth")),
+  ]);
+  return {
+    chainId,
+    mnemonic: args.mnemonic,
+    userCount: args.userCount ?? defaultArgs.userCount,
+    totalSupply: utils.parseUnits(
+      args.totalSupply ?? defaultArgs.totalSupply,
+      metadata.real.decimals,
+    ),
+    usdc,
+    usdcPerCow: utils.parseUnits(
+      args.usdcPerCow ?? defaultArgs.usdcPerCow,
+      usdc.decimals,
+    ),
+    gno,
+    usdcPerGno: utils.parseUnits(
+      args.usdcPerGno ?? defaultArgs.usdcPerGno,
+      usdc.decimals,
+    ),
+    weth,
+    usdcPerWeth: utils.parseUnits(
+      args.usdcPerWeth ?? defaultArgs.usdcPerWeth,
+      usdc.decimals,
+    ),
+  };
+}
+
+const setupTestDeploymentTask: () => void = () => {
+  task(
+    "test-deployment",
+    "Generate a list of pseudorandom claims for each signer and deploy test contracts on the current network.",
+  )
+    .addParam("mnemonic", "The mnemonic used to generate user addresses.")
+    .addOptionalParam(
+      "userCount",
+      "Random claims will be generated for this amount of users. Their secret key will be generated from the mnemonic.",
+      defaultArgs.userCount,
+      types.int,
+    )
+    .addOptionalParam(
+      "totalSupply",
+      "The total supply of real token minted on deployment.",
+      defaultArgs.totalSupply,
+      types.string,
+    )
+    .addOptionalParam("usdcToken", "Address of token USDC.")
+    .addOptionalParam("gnoToken", "Address of token GNO.")
+    .addOptionalParam("wethToken", "Address of token WETH.")
+    .addOptionalParam(
+      "usdcPerCow",
+      "How many USDC a COW is worth.",
+      defaultArgs.usdcPerCow,
+      types.string,
+    )
+    .addOptionalParam(
+      "usdcPerGno",
+      "How many USDC a GNO is worth.",
+      defaultArgs.usdcPerGno,
+      types.string,
+    )
+    .addOptionalParam(
+      "usdcPerWeth",
+      "How many USDC a WETH is worth.",
+      defaultArgs.usdcPerWeth,
+      types.string,
+    )
+    .setAction(async (args, hre) => {
+      await generateClaimsAndDeploy(await parseArgs(args, hre), hre);
+    });
+};
+
+function powerSet<T>(set: Set<T>): Set<Set<T>> {
+  const values = [...set.values()];
+  const result: Set<Set<T>> = new Set();
+  for (let i = 0; i < 2 ** values.length; i++) {
+    result.add(new Set(values.filter((_, pos) => (i & (1 << pos)) !== 0)));
+  }
+  return result;
+}
+
+function generateClaims(users: string[]): Claim[] {
+  // For every possible configuration of claims, there should be a user with
+  // these claims. An example of claim configuration is a user who has three
+  // claims: Investor, UserOption, and Airdrop.
+
+  // We filter out impossible configuration, that is a team claim with any other
+  // vesting claim. Also, we don't need users without claims.
+  const vestingClaimTypes = [
+    ClaimType.GnoOption,
+    ClaimType.UserOption,
+    ClaimType.Investor,
+  ];
+  const admissibleClaimConfigurations = [...powerSet(new Set(allClaimTypes))]
+    .filter(
+      (configuration) =>
+        !(
+          configuration.has(ClaimType.Team) &&
+          vestingClaimTypes.some((type) => configuration.has(type))
+        ),
+    )
+    .filter((configuration) => configuration.size !== 0);
+
+  const pseudorandomAmount = (i: number) =>
+    BigNumber.from(utils.id(i.toString()))
+      .mod(10000)
+      .mul(utils.parseUnits("1", metadata.real.decimals));
+  return users
+    .map((account, i) =>
+      Array.from(
+        admissibleClaimConfigurations[i % admissibleClaimConfigurations.length],
+      ).map((type) => ({
+        account,
+        claimableAmount: pseudorandomAmount(i),
+        type,
+      })),
+    )
+    .flat();
+}
+
+async function generateClaimsAndDeploy(
+  {
+    mnemonic,
+    userCount,
+    totalSupply,
+    usdc,
+    usdcPerCow,
+    gno,
+    usdcPerGno,
+    weth,
+    usdcPerWeth,
+    chainId,
+  }: CleanArgs,
+  hre: HardhatRuntimeEnvironment,
+) {
+  const { ethers } = hre;
+  const [deployer] = await ethers.getSigners();
+  const salt = id(Date.now().toString());
+  console.log(`Using deployer ${deployer.address}`);
+
+  console.log("Generating user PKs...");
+  const users = Array(userCount)
+    .fill(null)
+    .map((_, i) => {
+      process.stdout.cursorTo(0);
+      process.stdout.write(`${Math.floor((i * 100) / userCount)}%`);
+      return Wallet.fromMnemonic(mnemonic, `m/44'/60'/${i}'/0/0`);
+    });
+  process.stdout.cursorTo(0);
+  const privateKeys: Record<string, string> = {};
+  for (const user of users) {
+    privateKeys[user.address] = user.privateKey;
+  }
+
+  console.log("Generating user claims...");
+  const claims = generateClaims(users.map((user) => user.address));
+
+  console.log("Generating Merkle proofs...");
+  const { merkleRoot, claims: claimsWithProof } = computeProofs(claims);
+
+  // The contracts are deployed from a contract and require that some receiver
+  // addresses are set. All these are created now and are Gnosis Safe.
+  console.log("Deploying administration safes...");
+  const deploySafe: () => Promise<Contract> = async () =>
+    (await deployWithOwners([deployer.address], 1, deployer, hre)).connect(
+      ethers.provider,
+    );
+  const gnosisDao = await deploySafe();
+  const cowDao = await deploySafe();
+  const communityFundsTarget = await deploySafe();
+  const investorFundsTarget = await deploySafe();
+  const teamController = await deploySafe();
+
+  const realTokenDeployParams: RealTokenDeployParams = {
+    totalSupply,
+    cowDao: cowDao.address,
+  };
+
+  const virtualTokenDeployParams: Omit<VirtualTokenDeployParams, "realToken"> =
+    {
+      merkleRoot,
+      communityFundsTarget: communityFundsTarget.address,
+      investorFundsTarget: investorFundsTarget.address,
+      usdcToken: usdc.instance.address,
+      usdcPrice: usdcPerCow,
+      gnoToken: gno.instance.address,
+      gnoPrice: utils
+        .parseUnits("1", gno.decimals)
+        .mul(usdcPerCow)
+        .div(usdcPerGno),
+      wethToken: weth.instance.address,
+      wethPrice: utils
+        .parseUnits("1", weth.decimals)
+        .mul(usdcPerCow)
+        .div(usdcPerWeth),
+      teamController: teamController.address,
+    };
+
+  console.log("Generating deploy transactions...");
+  const {
+    realTokenDeployTransaction,
+    virtualTokenDeployTransaction,
+    realTokenAddress,
+    virtualTokenAddress,
+  } = await prepareSafeDeployment(
+    realTokenDeployParams,
+    virtualTokenDeployParams,
+    MultiSendDeployment.networkAddresses[chainId],
+    ethers,
+    salt,
+  );
+
+  expect(await ethers.provider.getCode(realTokenAddress)).to.equal("0x");
+  expect(await ethers.provider.getCode(virtualTokenAddress)).to.equal("0x");
+
+  console.log("Saving generated data to file...");
+  await fs.rmdir(OUTPUT_FOLDER, { recursive: true });
+  await fs.mkdir(OUTPUT_FOLDER);
+  await fs.writeFile(
+    `${OUTPUT_FOLDER}/private-keys.json`,
+    JSON.stringify(privateKeys),
+  );
+  await fs.writeFile(
+    `${OUTPUT_FOLDER}/claims.json`,
+    JSON.stringify(claimsWithProof),
+  );
+  await fs.writeFile(
+    `${OUTPUT_FOLDER}/params.json`,
+    JSON.stringify({
+      realTokenAddress,
+      virtualTokenAddress,
+      ...realTokenDeployParams,
+      ...virtualTokenDeployParams,
+    }),
+  );
+  await splitClaimsAndSaveToFolder(claimsWithProof, OUTPUT_FOLDER);
+
+  console.log("Deploying real token...");
+  const deploymentReal = await execSafeTransaction(
+    gnosisDao.connect(deployer),
+    realTokenDeployTransaction,
+    [deployer],
+  );
+  await expect(deploymentReal).to.emit(
+    gnosisDao.connect(ethers.provider),
+    "ExecutionSuccess",
+  );
+  expect(await ethers.provider.getCode(realTokenAddress)).not.to.equal("0x");
+
+  console.log("Deploying virtual token...");
+  const deploymentVirtual = await execSafeTransaction(
+    gnosisDao.connect(deployer),
+    virtualTokenDeployTransaction,
+    [deployer],
+  );
+  await expect(deploymentVirtual).to.emit(gnosisDao, "ExecutionSuccess");
+  expect(await ethers.provider.getCode(virtualTokenAddress)).not.to.equal("0x");
+}
+
+export { setupTestDeploymentTask };

--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -224,7 +224,7 @@ function generateClaims(users: string[]): Claim[] {
     .filter((configuration) => configuration.size !== 0);
 
   const pseudorandomAmount = (i: number) =>
-    BigNumber.from(utils.id(i.toString()))
+    BigNumber.from(id(i.toString()))
       .mod(10000)
       .mul(utils.parseUnits("1", metadata.real.decimals));
   return users

--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -17,7 +17,7 @@ import {
   allClaimTypes,
   computeProofs,
 } from "../ts";
-import { splitClaimsAndSaveToFolder } from "../ts/split";
+import { removeSplitClaimFiles, splitClaimsAndSaveToFolder } from "../ts/split";
 
 import {
   SupportedChainId,
@@ -335,9 +335,17 @@ async function generateClaimsAndDeploy(
   expect(await ethers.provider.getCode(realTokenAddress)).to.equal("0x");
   expect(await ethers.provider.getCode(virtualTokenAddress)).to.equal("0x");
 
+  console.log("Clearing old files");
+  await fs.rm(`${OUTPUT_FOLDER}/private-keys.json`, {
+    recursive: true,
+    force: true,
+  });
+  await fs.rm(`${OUTPUT_FOLDER}/claims.json`, { recursive: true, force: true });
+  await fs.rm(`${OUTPUT_FOLDER}/params.json`, { recursive: true, force: true });
+  await removeSplitClaimFiles(OUTPUT_FOLDER);
+
   console.log("Saving generated data to file...");
-  await fs.rmdir(OUTPUT_FOLDER, { recursive: true });
-  await fs.mkdir(OUTPUT_FOLDER);
+  await fs.mkdir(OUTPUT_FOLDER, { recursive: true });
   await fs.writeFile(
     `${OUTPUT_FOLDER}/private-keys.json`,
     JSON.stringify(privateKeys),

--- a/src/tasks/ts/safe.ts
+++ b/src/tasks/ts/safe.ts
@@ -1,0 +1,102 @@
+import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { TypedDataSigner } from "@ethersproject/abstract-signer";
+import {
+  buildSafeTransaction,
+  executeTxWithSigners,
+  MetaTransaction,
+} from "@gnosis.pm/safe-contracts";
+import GnosisSafe from "@gnosis.pm/safe-contracts/build/artifacts/contracts/GnosisSafe.sol/GnosisSafe.json";
+import GnosisSafeProxyFactory from "@gnosis.pm/safe-contracts/build/artifacts/contracts/proxies/GnosisSafeProxyFactory.sol/GnosisSafeProxyFactory.json";
+import GnosisSafeDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/gnosis_safe.json";
+import MultiSendDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/multi_send_call_only.json";
+import GnosisSafeProxyFactoryDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/proxy_factory.json";
+import { constants, Contract, ContractReceipt, Signer, Wallet } from "ethers";
+import { Interface } from "ethers/lib/utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export { MultiSendDeployment };
+
+export type SupportedChainId =
+  keyof typeof GnosisSafeProxyFactoryDeployment.networkAddresses &
+    keyof typeof GnosisSafeDeployment.networkAddresses &
+    keyof typeof MultiSendDeployment.networkAddresses;
+
+export function isChainIdSupported(
+  chainId: string,
+): chainId is SupportedChainId {
+  return (
+    Object.keys(GnosisSafeProxyFactoryDeployment.networkAddresses).includes(
+      chainId,
+    ) &&
+    Object.keys(GnosisSafeDeployment.networkAddresses).includes(chainId) &&
+    Object.keys(MultiSendDeployment.networkAddresses).includes(chainId)
+  );
+}
+
+export async function execSafeTransaction(
+  safe: Contract,
+  transaction: MetaTransaction,
+  signers: (Signer & TypedDataSigner)[],
+): Promise<TransactionResponse> {
+  const safeTransaction = buildSafeTransaction({
+    ...transaction,
+    nonce: await safe.nonce(),
+  });
+
+  // Hack: looking at the call stack of the imported function
+  // `executeTxWithSigners`, it is enough that the signer's type is `Signer &
+  // TypedDataSigner`. However, the Safe library function requires the signers'
+  // type to be `Wallet`. We coerce the type to be able to use this function
+  // with signers without reimplementing all execution and signing routines.
+  return await executeTxWithSigners(safe, safeTransaction, signers as Wallet[]);
+}
+
+export async function deployWithOwners(
+  owners: string[],
+  threshold: number,
+  deployer: Signer,
+  { ethers }: HardhatRuntimeEnvironment,
+): Promise<Contract> {
+  const chainId = (await ethers.provider.getNetwork()).chainId.toString();
+  if (!isChainIdSupported(chainId)) {
+    throw new Error(`Chain id ${chainId} not supported by the Gnosis Safe`);
+  }
+  const proxyFactory = await ethers.getContractAt(
+    GnosisSafeProxyFactory.abi,
+    GnosisSafeProxyFactoryDeployment.networkAddresses[chainId],
+  );
+  const GnosisSafeInterface = new Interface(GnosisSafe.abi);
+  const setupOwnersBytecode = GnosisSafeInterface.encodeFunctionData("setup", [
+    owners,
+    threshold,
+    constants.AddressZero,
+    "0x",
+    constants.AddressZero,
+    constants.AddressZero,
+    constants.Zero,
+    constants.AddressZero,
+  ]);
+  const deployTransaction: ContractReceipt = await (
+    await proxyFactory
+      .connect(deployer)
+      .createProxy(
+        GnosisSafeDeployment.networkAddresses[chainId],
+        setupOwnersBytecode,
+      )
+  ).wait();
+  const proxyCreationEvents = deployTransaction.events?.filter(
+    (e) => e.event === "ProxyCreation",
+  );
+  const newSafeAddress: string | undefined =
+    proxyCreationEvents?.[0]?.args?.proxy;
+  if (
+    proxyCreationEvents === undefined ||
+    proxyCreationEvents.length !== 1 ||
+    newSafeAddress === undefined
+  ) {
+    throw new Error(
+      "Error reading proxy creation event when creating new Safe",
+    );
+  }
+  return new Contract(newSafeAddress, GnosisSafe.abi);
+}

--- a/src/ts/claim.ts
+++ b/src/ts/claim.ts
@@ -32,6 +32,10 @@ export interface ExecutableClaim extends ProvenClaim {
   value?: BigNumber;
 }
 
+export const allClaimTypes: ClaimType[] = Object.keys(ClaimType)
+  .map((c) => Number(c))
+  .filter((c) => !isNaN(c));
+
 // Returns a collision-free identifier for the pair (claim, index).
 export function claimHash(
   index: number | BigNumber,

--- a/src/ts/split.ts
+++ b/src/ts/split.ts
@@ -86,7 +86,6 @@ export async function splitClaimsAndSaveToFolder(
   const { claimChunks, addressChunks } = splitClaims(claims);
   await fs.writeFile(`${path}/mapping.json`, JSON.stringify(addressChunks));
   const chunksDir = `${path}/chunks`;
-  await fs.rmdir(chunksDir, { recursive: true });
   await fs.mkdir(chunksDir);
   for (const [firstAddress, chunk] of Object.entries(claimChunks)) {
     await fs.writeFile(
@@ -94,4 +93,9 @@ export async function splitClaimsAndSaveToFolder(
       JSON.stringify(chunk),
     );
   }
+}
+
+export async function removeSplitClaimFiles(path: string) {
+  await fs.rm(`${path}/mapping.json`, { recursive: true, force: true });
+  await fs.rm(`${path}/chunks`, { recursive: true, force: true });
 }

--- a/src/ts/split.ts
+++ b/src/ts/split.ts
@@ -1,0 +1,112 @@
+// The functions in this file are responsible for splitting the list of claims
+// into multiple smaller files that are cheaper to load by the frontend.
+//
+// The code is similar to the code used for the same purpose by Uniswap:
+// https://github.com/Uniswap/mrkl-drop-data-chunks/blob/c215bf1e4360205acdc6c154389b10a2f287974d/split.ts
+
+import { promises as fs } from "fs";
+
+import { ClaimType, ProvenClaim } from "./claim";
+
+export type FirstAddress = string;
+export type LastAddress = string;
+export type AddressChunks = { [address: FirstAddress]: LastAddress };
+export type ClaimChunk = Record<string, StringifiedProvenClaim[]>;
+export type ClaimChunks = Record<FirstAddress, ClaimChunk>;
+
+export interface StringifiedProvenClaim {
+  type: string;
+  amount: string;
+  index: number;
+  proof: string[];
+}
+
+export interface SplitClaims {
+  addressChunks: AddressChunks;
+  claimChunks: ClaimChunks;
+}
+
+/**
+ * Splits the input claims into cohorts of approximatively the same byte size.
+ * Each cohort is identified by the first (lexicographically sorted) address
+ * in the cohort. A separate entry links the first address to the last address
+ * of the cohort.
+ *
+ * @param claims The claims to split in distinct chuncks.
+ * @param maxCohortSize The appriximate maximum size of a cohort in bytes.
+ */
+export function splitClaims(
+  claims: ProvenClaim[],
+  maxCohortSize = 200000,
+): SplitClaims {
+  const sortedAddresses: string[] = claims
+    .map(({ account }) => account)
+    .filter(
+      (account, i, thisArg) => thisArg.findIndex((a) => a === account) === i,
+    );
+  sortedAddresses.sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
+
+  const claimsByAddress: Record<string, StringifiedProvenClaim[]> = {};
+  for (const user of sortedAddresses) {
+    claimsByAddress[user] = claims
+      .filter(({ account }) => account === user)
+      .map((claim) => ({
+        proof: claim.proof,
+        index: claim.index,
+        type: ClaimType[claim.type],
+        amount: claim.claimableAmount.toString(),
+      }));
+  }
+
+  const addressChunks: AddressChunks = {};
+  const claimChunks: ClaimChunks = {};
+  let currentClaimChunk: ClaimChunk = {};
+  let firstAddressInChunk: FirstAddress = sortedAddresses[0];
+  let currentChunckSize = 0;
+  for (const [currentUserIndex, currentUser] of Array.from(
+    sortedAddresses.entries(),
+  )) {
+    const sizeExtraUser = JSON.stringify(claimsByAddress[currentUser]).length;
+    if (sizeExtraUser + currentChunckSize < maxCohortSize) {
+      currentClaimChunk[currentUser] = claimsByAddress[currentUser];
+      currentChunckSize += sizeExtraUser;
+    } else {
+      if (sizeExtraUser > maxCohortSize) {
+        throw new Error(
+          `Claim of user ${currentUser} is too large and cannot be stored in a single file.`,
+        );
+      }
+      addressChunks[firstAddressInChunk] =
+        sortedAddresses[currentUserIndex - 1];
+      claimChunks[firstAddressInChunk] = currentClaimChunk;
+      // prepare next chunk
+      firstAddressInChunk = currentUser;
+      currentClaimChunk = {};
+      currentClaimChunk[currentUser] = claimsByAddress[currentUser];
+      currentChunckSize = sizeExtraUser;
+    }
+  }
+  if (Object.keys(currentClaimChunk).length !== 0) {
+    claimChunks[firstAddressInChunk] = currentClaimChunk;
+    addressChunks[firstAddressInChunk] =
+      sortedAddresses[sortedAddresses.length - 1];
+  }
+  return { claimChunks, addressChunks };
+}
+
+export async function splitClaimsAndSaveToFolder(
+  claims: ProvenClaim[],
+  path: string,
+) {
+  const { claimChunks, addressChunks } = splitClaims(claims);
+  await fs.writeFile(`${path}/mapping.json`, JSON.stringify(addressChunks));
+  const chunksDir = `${path}/chunks`;
+  await fs.rmdir(chunksDir, { recursive: true });
+  await fs.mkdir(chunksDir);
+  for (const [firstAddress, chunk] of Object.entries(claimChunks)) {
+    await fs.writeFile(
+      `${chunksDir}/${firstAddress}.json`,
+      JSON.stringify(chunk),
+    );
+  }
+}

--- a/test/CowSwapVirtualToken.test.ts
+++ b/test/CowSwapVirtualToken.test.ts
@@ -14,15 +14,12 @@ import {
   computeProofs,
   getClaimInput,
   ProvenClaim,
+  allClaimTypes,
 } from "../src/ts";
 
 import { fullyExecuteClaim } from "./claiming";
 import { customError } from "./custom-errors";
 import { setTime, setTimeAndMineBlock } from "./utils/timeUtils";
-
-const allClaimTypes: ClaimType[] = Object.keys(ClaimType)
-  .map((c) => Number(c))
-  .filter((c) => !isNaN(c));
 
 describe("CowProtocolVirtualToken", () => {
   let token: Contract;

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -2,6 +2,7 @@ import { Contract } from "@ethersproject/contracts";
 import { expect } from "chai";
 import hre, { ethers, waffle } from "hardhat";
 
+import { execSafeTransaction } from "../src/tasks/ts/safe";
 import {
   metadata,
   prepareSafeDeployment,
@@ -11,7 +12,7 @@ import {
 } from "../src/ts";
 
 import { setupDeployer } from "./deterministic-deployment";
-import { execSafeTransaction, GnosisSafeManager } from "./safe";
+import { GnosisSafeManager } from "./safe";
 import { skipOnCoverage } from "./test-management";
 
 describe("deployment", () => {

--- a/test/multisend.test.ts
+++ b/test/multisend.test.ts
@@ -1,9 +1,10 @@
 import { expect } from "chai";
 import { ethers, waffle } from "hardhat";
 
+import { execSafeTransaction } from "../src/tasks/ts/safe";
 import { multisend } from "../src/ts/deploy/safe";
 
-import { execSafeTransaction, GnosisSafeManager } from "./safe";
+import { GnosisSafeManager } from "./safe";
 
 describe("multisend", () => {
   const [ethSource, deployer, ...owners] = waffle.provider.getWallets();

--- a/test/safe.ts
+++ b/test/safe.ts
@@ -1,13 +1,7 @@
-import { TransactionResponse } from "@ethersproject/abstract-provider";
-import {
-  buildSafeTransaction,
-  executeTxWithSigners,
-  MetaTransaction,
-} from "@gnosis.pm/safe-contracts";
 import GnosisSafe from "@gnosis.pm/safe-contracts/build/artifacts/contracts/GnosisSafe.sol/GnosisSafe.json";
 import MultiSend from "@gnosis.pm/safe-contracts/build/artifacts/contracts/libraries/MultiSend.sol/MultiSend.json";
 import GnosisSafeProxyFactory from "@gnosis.pm/safe-contracts/build/artifacts/contracts/proxies/GnosisSafeProxyFactory.sol/GnosisSafeProxyFactory.json";
-import { Signer, Contract, Wallet } from "ethers";
+import { Signer, Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 export class GnosisSafeManager {
@@ -47,17 +41,4 @@ export class GnosisSafeManager {
     );
     return safe;
   }
-}
-
-export async function execSafeTransaction(
-  safe: Contract,
-  transaction: MetaTransaction,
-  signers: Wallet[],
-): Promise<TransactionResponse> {
-  const safeTransaction = buildSafeTransaction({
-    ...transaction,
-    nonce: await safe.nonce(),
-  });
-
-  return await executeTxWithSigners(safe, safeTransaction, signers);
 }


### PR DESCRIPTION
Note: the first commit of this PR has code that was already read (and in part approved) by the people I'm requesting a review from. The logic doesn't need to be checked again except for the (few) new changes that were discussed in the previous reviews, which appear in separate commits.

when developing the smart contract, so the reviews in there still apply to this PR. That PR was ready to merge except for two comments that I will discuss here.

### Description

Creates a script that generates pseudorandom claims and deploys the token contracts on the chosen network.
It tries to make a realistic deployment, so all address parameters of the deployment (like the DAO or the fund targets) are Gnosis Safes, owned by the deployer.

It can be used to generate a test deployment on Rinkeby that the frontend can use to test that the website works.

This is how the script can be used:

```
$ npx hardhat test-deployment --help
Hardhat version 2.7.1

Usage: hardhat [GLOBAL OPTIONS] test-deployment --gno-token <STRING> --mnemonic <STRING> [--total-supply <STRING>] [--usdc-per-cow <STRING>] [--usdc-per-gno <STRING>] [--usdc-per-weth <STRING>] --usdc-token <STRING> [--user-count <INT>] --weth-token <STRING>

OPTIONS:

  --gno-token           Address of token GNO. 
  --mnemonic            The mnemonic used to generate user addresses. 
  --total-supply        The total supply of real token minted on deployment. (default: "1000000000000")
  --usdc-per-cow        How many USDC a COW is worth. (default: "0.15")
  --usdc-per-gno        How many USDC a GNO is worth. (default: "400")
  --usdc-per-weth       How many USDC a WETH is worth. (default: "4000")
  --usdc-token          Address of token USDC. 
  --user-count          Random claims will be generated for this amount of users. Their secret key will be generated from the mnemonic. (default: 1000)
  --weth-token          Address of token WETH. 

test-deployment: Generate a list of pseudorandom claims for each signer and deploy test contracts on the current network.

For global options help run: hardhat help
```

### Test Plan

Run the script on Rinkeby and see that the deployment work. For example:

```
$ npx hardhat test-deployment --network rinkeby --user-count 100 --mnemonic "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
Using deployer 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
Generating user PKs...
Generating user claims...
Gemerating Merkle proofs...
Deploying administration safes...
Generating deploy transactions...
Saving generated data to file...
Deploying real token...
Deploying virtual token...
```

The frontend is currently using deployments generated with this script.

The final output can be sanity-checked with the following script:
<details><summary>script.ts</summary>

```
import { promises as fs } from "fs";

const OUTPUT_FOLDER = "output/";

async function main() {
  const mapping: Record<string, string> = JSON.parse(
    (await fs.readFile(`${OUTPUT_FOLDER}/mapping.json`)).toString(),
  );
  const allAddresses: string[] = [];
  for (const [key, value] of Object.entries(mapping)) {
    const chunk: Record<string, unknown> = await JSON.parse(
      (await fs.readFile(`${OUTPUT_FOLDER}/chunks/${key}.json`)).toString(),
    );
    const addressesInChunk = Object.keys(chunk).sort((lhs, rhs) =>
      lhs.toLowerCase() < rhs.toLowerCase() ? -1 : 1,
    );
    const repeatingAddreses = addressesInChunk.filter((address) =>
      allAddresses.includes(address),
    );
    if (repeatingAddreses.length !== 0) {
      throw new Error(
        `Address(es) ${repeatingAddreses.join(
          ", ",
        )} also appear in a chunk before ${key}`,
      );
    } else {
      allAddresses.push(...addressesInChunk);
    }
    const firstAddress = addressesInChunk[0];
    if (firstAddress !== key) {
      throw new Error(
        `Invalid start of chunk ${key}: found ${firstAddress} instead of ${key}}`,
      );
    }
    const lastAddress = addressesInChunk[addressesInChunk.length - 1];
    if (lastAddress !== value) {
      throw new Error(
        `Invalid end of chunk ${key}: found ${lastAddress} instead of ${value}`,
      );
    }
  }
  console.log(`Found ${allAddresses.length} distinct addresses in chunks.`);
}

main().catch((e) => console.error(e));
```
</details>

Verify that the final output is correct by running the script and verifying that the number of unique addresses is the same as the number of addresses used in --user-count. For example, for the latest deployment we use:
```
$ npx ts-node script.ts 
Found 10000 distinct addresses in chunks.
```