### PR TITLE
Test that the funds target receives ETH

### DIFF
--- a/test/Claiming.test.ts
+++ b/test/Claiming.test.ts
@@ -467,6 +467,24 @@ describe("Claiming", function () {
             });
 
             testOptionClaim(testParams, ethProceeds);
+
+            it(`sends ETH to the ${testParams.fundsTarget} target`, async function () {
+              const initialBalance = await ethers.provider.getBalance(
+                target(testParams.fundsTarget),
+              );
+              await claiming.performClaimTest(
+                testParams.claimType,
+                payer,
+                claimant,
+                amount,
+                ethProceeds,
+              );
+              expect(
+                await ethers.provider.getBalance(
+                  target(testParams.fundsTarget),
+                ),
+              ).to.equal(initialBalance.add(ethProceeds));
+            });
           });
 
           it("reverts if sending too little ETH", async function () {


### PR DESCRIPTION
In a comment of #19, @josojo noticed that this test was missing.

Adds a test that verifies that the funds target actually receives ETH when a claim involving eth is executed. 

### Test Plan

New code is a test. In the console output, observe the new line:
```
UserOption
        [...]
        can use ETH for claiming
              [...]
          ✓ sends ETH to the communityFunds target
```
