### PR TITLE
adding e2e user option test

### DIFF
--- a/src/contracts/test/TestERC20.sol
+++ b/src/contracts/test/TestERC20.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
+
+contract TestERC20 is ERC20PresetMinterPauser {
+    constructor(string memory symbol)
+        ERC20PresetMinterPauser(symbol, symbol) // solhint-disable-next-line no-empty-blocks
+    {}
+}

--- a/src/contracts/test/TestERC20.sol
+++ b/src/contracts/test/TestERC20.sol
@@ -4,7 +4,15 @@ pragma solidity ^0.8.10;
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 
 contract TestERC20 is ERC20PresetMinterPauser {
-    constructor(string memory symbol)
+    uint8 private _decimals;
+
+    constructor(string memory symbol, uint8 erc20Decimals)
         ERC20PresetMinterPauser(symbol, symbol) // solhint-disable-next-line no-empty-blocks
-    {}
+    {
+        _decimals = erc20Decimals;
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
 }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -168,6 +168,9 @@ describe("e2e-tests", () => {
     expect(await deploymentData.vCowToken.balanceOf(user.address)).to.be.equal(
       claim.claimableAmount,
     );
+    expect(
+      await deploymentData.wethToken.balanceOf(communityFundsTarget.address),
+    ).to.be.equal(wethToPay);
     await expect(
       deploymentData.vCowToken.connect(user).swapAll(),
     ).to.be.revertedWith("ERC20: transfer amount exceeds balance");

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -36,7 +36,6 @@ interface DeploymentParameters {
   usdcPrice: BigNumber;
   gnoPrice: BigNumber;
   nativeTokenPrice: BigNumber;
-  usdPerCow: BigNumber;
   initialCowSupply: BigNumber;
 }
 
@@ -45,11 +44,9 @@ async function standardDeployment(
 ): Promise<DeploymentData> {
   // Deploy the required tokens
   const TestERC20 = await ethers.getContractFactory("TestERC20");
-  const usdcToken = await TestERC20.deploy("USDC");
-  const gnoToken = await TestERC20.deploy("GNO");
-  const wethToken = await TestERC20.connect(
-    deploymentParameters.deployer,
-  ).deploy("WETH");
+  const usdcToken = await TestERC20.deploy("USDC", 6);
+  const gnoToken = await TestERC20.deploy("GNO", 18);
+  const wethToken = await TestERC20.deploy("WETH", 18);
 
   // Deploying of the CowToken
   const CowSwapToken = await ethers.getContractFactory(ContractName.RealToken);
@@ -101,7 +98,7 @@ describe("e2e-tests", () => {
   const [
     deployer,
     user,
-    user_not_eligible,
+    userNotEligible,
     cowDao,
     communityFundsTarget,
     investorFundsTarget,
@@ -126,7 +123,7 @@ describe("e2e-tests", () => {
   let claim: Claim;
   let claims: ProvenClaim[];
 
-  it("User Option: claims the user option and vest it", async () => {
+  it("User Option: claims the user option with WETH and vest it", async () => {
     claim = {
       account: user.address,
       claimableAmount: ethers.utils.parseUnits("1234", 18),
@@ -145,7 +142,6 @@ describe("e2e-tests", () => {
       usdcPrice,
       gnoPrice,
       nativeTokenPrice,
-      usdPerCow,
       initialCowSupply,
     };
     deploymentData = await standardDeployment(deploymentParameters);
@@ -179,24 +175,28 @@ describe("e2e-tests", () => {
     // Send cowTokens to the vCowToken
     await deploymentData.cowToken
       .connect(cowDao)
-      .transfer(deploymentData.vCowToken.address, claim.claimableAmount.div(2));
+      .transfer(deploymentData.vCowToken.address, initialCowSupply);
 
     // Perform a swapAll
     const vestingPeriod =
       await deploymentData.vCowToken.VESTING_PERIOD_IN_SECONDS();
-    setTime(deploymentData.deploymentTimestamp + vestingPeriod / 2);
+    setTime(deploymentData.deploymentTimestamp + vestingPeriod / 4);
     await deploymentData.vCowToken.connect(user).swapAll();
     expect(await deploymentData.cowToken.balanceOf(user.address)).to.be.equal(
-      claim.claimableAmount.div(2),
+      claim.claimableAmount.div(4),
     );
     expect(
       await deploymentData.cowToken.balanceOf(deploymentData.vCowToken.address),
-    ).to.be.equal(0);
+    ).to.be.equal(initialCowSupply.sub(claim.claimableAmount.div(4)));
     expect(await deploymentData.vCowToken.totalSupply()).to.be.equal(
-      vCowTokenSupply.sub(claim.claimableAmount.div(2)),
+      vCowTokenSupply.sub(claim.claimableAmount.div(4)),
+    );
+    expect(await deploymentData.vCowToken.balanceOf(user.address)).to.equal(
+      claim.claimableAmount.mul(3).div(4),
     );
   });
-  it("User Option: claims the user option on behalf of someone else", async () => {
+
+  it("User Option: claims the user option on behalf of someone else with ETH", async () => {
     claim = {
       account: user.address,
       claimableAmount: ethers.utils.parseUnits("1234", 18),
@@ -215,40 +215,41 @@ describe("e2e-tests", () => {
       usdcPrice,
       gnoPrice,
       nativeTokenPrice,
-      usdPerCow,
       initialCowSupply,
     };
     deploymentData = await standardDeployment(deploymentParameters);
 
-    const wethToPay = claim.claimableAmount
+    const ethToPay = claim.claimableAmount
       .mul(nativeTokenPrice)
       .div(priceDenominator);
+    const ethBalanceOfCommunityFundsTarget = await ethers.provider.getBalance(
+      communityFundsTarget.address,
+    );
     await deploymentData.wethToken
       .connect(deployer)
-      .mint(user_not_eligible.address, wethBalanceOfUser);
+      .mint(userNotEligible.address, wethBalanceOfUser);
     // Claim vCowTokens
-    await deploymentData.wethToken
-      .connect(user_not_eligible)
-      .approve(deploymentData.vCowToken.address, wethToPay);
     let executeClaim = fullyExecuteClaim(claims[0]);
     executeClaim.claimedAmount = executeClaim.claimedAmount.div(2);
     await expect(
       deploymentData.vCowToken
-        .connect(user_not_eligible)
-        .claim(...getClaimInput(executeClaim)),
+        .connect(userNotEligible)
+        .claim(...getClaimInput(executeClaim), { value: ethToPay.div(2) }),
     ).to.be.revertedWith("OnlyOwnerCanClaimPartially()");
 
     executeClaim = fullyExecuteClaim(claims[0]);
     await deploymentData.vCowToken
-      .connect(user_not_eligible)
-      .claim(...getClaimInput(fullyExecuteClaim(claims[0])));
+      .connect(userNotEligible)
+      .claim(...getClaimInput(fullyExecuteClaim(claims[0])), {
+        value: ethToPay,
+      });
 
     vCowTokenSupply = await deploymentData.vCowToken.totalSupply();
     expect(vCowTokenSupply).to.be.equal(claim.claimableAmount);
 
     expect(
-      await deploymentData.wethToken.balanceOf(user_not_eligible.address),
-    ).to.be.equal(wethBalanceOfUser.sub(wethToPay));
+      await ethers.provider.getBalance(communityFundsTarget.address),
+    ).to.be.equal(ethToPay.add(ethBalanceOfCommunityFundsTarget));
     expect(await deploymentData.vCowToken.balanceOf(user.address)).to.be.equal(
       claim.claimableAmount,
     );
@@ -274,6 +275,9 @@ describe("e2e-tests", () => {
     ).to.be.equal(0);
     expect(await deploymentData.vCowToken.totalSupply()).to.be.equal(
       vCowTokenSupply.sub(claim.claimableAmount.div(2)),
+    );
+    expect(await deploymentData.vCowToken.balanceOf(user.address)).to.equal(
+      claim.claimableAmount.div(2),
     );
   });
 });

--- a/test/e2eUserOption.test.ts
+++ b/test/e2eUserOption.test.ts
@@ -1,0 +1,252 @@
+import { expect } from "chai";
+import { BigNumber, Contract, utils, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  Claim,
+  ClaimType,
+  computeProofs,
+  constructorInput,
+  ContractName,
+  getClaimInput,
+  ProvenClaims,
+  RealTokenDeployParams,
+  VirtualTokenDeployParams,
+} from "../src/ts";
+
+import { fullyExecuteClaim } from "./claiming";
+import { setTime } from "./utils/timeUtils";
+
+interface DeploymentData {
+  cowToken: Contract;
+  vCowToken: Contract;
+  usdcToken: Contract;
+  gnoToken: Contract;
+  wethToken: Contract;
+  deploymentTimestamp: number;
+}
+interface DeploymentParameters {
+  deployer: Wallet;
+  cowDao: Wallet;
+  investorFundsTarget: Wallet;
+  teamController: Wallet;
+  communityFundsTarget: Wallet;
+  provenClaims: ProvenClaims;
+  usdcPrice: BigNumber;
+  gnoPrice: BigNumber;
+  cowPerWethPriceNumerator: BigNumber;
+  usdPerCow: BigNumber;
+  initialCowSupply: BigNumber;
+}
+
+async function standardDeployment(
+  deploymentParameters: DeploymentParameters,
+): Promise<DeploymentData> {
+  // Deploy the required tokens
+  const TestERC20 = await ethers.getContractFactory("TestERC20");
+  const usdcToken = await TestERC20.deploy("USDC");
+  const gnoToken = await TestERC20.deploy("GNO");
+  const wethToken = await TestERC20.connect(
+    deploymentParameters.deployer,
+  ).deploy("WETH");
+
+  // Deploying of the CowToken
+  const CowSwapToken = await ethers.getContractFactory(ContractName.RealToken);
+  const realTokenDeploymentParams: RealTokenDeployParams = {
+    cowDao: deploymentParameters.cowDao.address,
+    totalSupply: deploymentParameters.initialCowSupply,
+  };
+  const cowToken = await CowSwapToken.deploy(
+    ...constructorInput(ContractName.RealToken, realTokenDeploymentParams),
+  );
+
+  // Deploying of the CowSwapVirtualToken
+  const CowSwapVirtualToken = await ethers.getContractFactory(
+    ContractName.VirtualToken,
+  );
+  const deploymentParams: VirtualTokenDeployParams = {
+    merkleRoot: deploymentParameters.provenClaims.merkleRoot,
+    realToken: cowToken.address,
+    investorFundsTarget: deploymentParameters.investorFundsTarget.address,
+    gnoToken: gnoToken.address,
+    usdcToken: usdcToken.address,
+    wrappedNativeToken: wethToken.address,
+    communityFundsTarget: deploymentParameters.communityFundsTarget.address,
+    usdcPrice: deploymentParameters.usdcPrice,
+    gnoPrice: deploymentParameters.gnoPrice,
+    nativeTokenPrice: deploymentParameters.cowPerWethPriceNumerator,
+    teamController: deploymentParameters.teamController.address,
+  };
+  const vCowToken = await CowSwapVirtualToken.deploy(
+    ...constructorInput(ContractName.VirtualToken, deploymentParams),
+  );
+  const deploymentTimestamp = (await ethers.provider.getBlock("latest"))
+    .timestamp;
+
+  return {
+    cowToken,
+    vCowToken,
+    usdcToken,
+    gnoToken,
+    wethToken,
+    deploymentTimestamp,
+  };
+}
+
+describe("e2e user option", () => {
+  // In the actual deployment cowDAO, communityFundsTarget, investorFundsTarget, teamController are all gnosis safes.
+  // But to keep the e2e tests simple, we use normal EOA.
+  // This should not make a difference, as in the e2e tests they are only used to send and receive tokens
+  const [
+    deployer,
+    user,
+    user_not_eligible,
+    cowDao,
+    communityFundsTarget,
+    investorFundsTarget,
+    teamController,
+  ] = waffle.provider.getWallets();
+  const initialCowSupply = ethers.utils.parseEther("1000");
+  const claim: Claim = {
+    account: user.address,
+    claimableAmount: ethers.utils.parseUnits("234", 18),
+    type: ClaimType.UserOption,
+  };
+  const provenClaims = computeProofs([claim]);
+
+  // Prices are chosen to be realistic but yet easy to work with, so that the
+  // test amounts are meaningful.
+  // - 1 COW = 0.15 USDC
+  const usdcPrice = utils.parseUnits("0.15", 6);
+  // - 1 GNO = 400 USDC
+  const gnoPrice = utils.parseUnits("0.15", 18).div(400);
+  const usdPerCow = ethers.utils.parseEther("0.15");
+  // - 1 WETH = 4000 USDC
+  const cowPerWethPriceNumerator = usdPerCow.div(4000);
+  const cowPerWethPriceDenominator = ethers.utils.parseEther("1");
+  const wethBalanceOfUser = ethers.utils.parseUnits("234", 18);
+
+  let deploymentData: DeploymentData;
+
+  beforeEach(async function () {
+    const deploymentParameters: DeploymentParameters = {
+      deployer,
+      cowDao,
+      communityFundsTarget,
+      investorFundsTarget,
+      teamController,
+      provenClaims,
+      usdcPrice,
+      gnoPrice,
+      cowPerWethPriceNumerator,
+      usdPerCow,
+      initialCowSupply,
+    };
+    deploymentData = await standardDeployment(deploymentParameters);
+  });
+  const { claims } = provenClaims;
+
+  const wethToPay = claim.claimableAmount
+    .mul(cowPerWethPriceNumerator)
+    .div(cowPerWethPriceDenominator);
+
+  it("claims the user option and vest it", async () => {
+    await deploymentData.wethToken
+      .connect(deployer)
+      .mint(user.address, wethBalanceOfUser);
+    // Claim vCowTokens
+    await deploymentData.wethToken
+      .connect(user)
+      .approve(deploymentData.vCowToken.address, wethToPay);
+    await deploymentData.vCowToken
+      .connect(user)
+      .claim(...getClaimInput(fullyExecuteClaim(claims[0])));
+
+    const vCowTokenSupply = await deploymentData.vCowToken.totalSupply();
+    expect(vCowTokenSupply).to.be.equal(claim.claimableAmount);
+
+    expect(await deploymentData.wethToken.balanceOf(user.address)).to.be.equal(
+      wethBalanceOfUser.sub(wethToPay),
+    );
+    expect(await deploymentData.vCowToken.balanceOf(user.address)).to.be.equal(
+      claim.claimableAmount,
+    );
+    await expect(
+      deploymentData.vCowToken.connect(user).swapAll(),
+    ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+
+    // Send cowTokens to the vCowToken
+    await deploymentData.cowToken
+      .connect(cowDao)
+      .transfer(deploymentData.vCowToken.address, claim.claimableAmount.div(2));
+
+    // Perform a swapAll
+    const vestingPeriod =
+      await deploymentData.vCowToken.VESTING_PERIOD_IN_SECONDS();
+    setTime(deploymentData.deploymentTimestamp + vestingPeriod / 2);
+    await deploymentData.vCowToken.connect(user).swapAll();
+    expect(await deploymentData.cowToken.balanceOf(user.address)).to.be.equal(
+      claim.claimableAmount.div(2),
+    );
+    expect(
+      await deploymentData.cowToken.balanceOf(deploymentData.vCowToken.address),
+    ).to.be.equal(0);
+    expect(await deploymentData.vCowToken.totalSupply()).to.be.equal(
+      vCowTokenSupply.sub(claim.claimableAmount.div(2)),
+    );
+  });
+  it("claims the user option on behalf of someone else", async () => {
+    await deploymentData.wethToken
+      .connect(deployer)
+      .mint(user_not_eligible.address, wethBalanceOfUser);
+    // Claim vCowTokens
+    await deploymentData.wethToken
+      .connect(user_not_eligible)
+      .approve(deploymentData.vCowToken.address, wethToPay);
+    let executeClaim = fullyExecuteClaim(claims[0]);
+    executeClaim.claimedAmount = executeClaim.claimedAmount.div(2);
+    await expect(
+      deploymentData.vCowToken
+        .connect(user_not_eligible)
+        .claim(...getClaimInput(executeClaim)),
+    ).to.be.revertedWith("OnlyOwnerCanClaimPartially()");
+
+    executeClaim = fullyExecuteClaim(claims[0]);
+    await deploymentData.vCowToken
+      .connect(user_not_eligible)
+      .claim(...getClaimInput(fullyExecuteClaim(claims[0])));
+
+    const vCowTokenSupply = await deploymentData.vCowToken.totalSupply();
+    expect(vCowTokenSupply).to.be.equal(claim.claimableAmount);
+
+    expect(
+      await deploymentData.wethToken.balanceOf(user_not_eligible.address),
+    ).to.be.equal(wethBalanceOfUser.sub(wethToPay));
+    expect(await deploymentData.vCowToken.balanceOf(user.address)).to.be.equal(
+      claim.claimableAmount,
+    );
+    await expect(
+      deploymentData.vCowToken.connect(user).swapAll(),
+    ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+
+    // Send cowTokens to the vCowToken
+    await deploymentData.cowToken
+      .connect(cowDao)
+      .transfer(deploymentData.vCowToken.address, claim.claimableAmount.div(2));
+
+    // Perform a swapAll
+    const vestingPeriod =
+      await deploymentData.vCowToken.VESTING_PERIOD_IN_SECONDS();
+    setTime(deploymentData.deploymentTimestamp + vestingPeriod / 2);
+    await deploymentData.vCowToken.connect(user).swapAll();
+    expect(await deploymentData.cowToken.balanceOf(user.address)).to.be.equal(
+      claim.claimableAmount.div(2),
+    );
+    expect(
+      await deploymentData.cowToken.balanceOf(deploymentData.vCowToken.address),
+    ).to.be.equal(0);
+    expect(await deploymentData.vCowToken.totalSupply()).to.be.equal(
+      vCowTokenSupply.sub(claim.claimableAmount.div(2)),
+    );
+  });
+});


### PR DESCRIPTION
Finishes the PR for the e2e test.

Initially, we said that we want to use exactly the same deployment strategy as we have in the final deployment. But I think this only makes the tests more complicated, and does not add value for these integration testing purposes.

We will do a separate testing of the deployment and one simple claim with a mainnet hardhat-fork for testing the real deployment.

I address the comments from Federico in the original PR.

The PR is still in draft, as I don't know how to set best the USDC token. The new openzepplin libraries only support tokens with 18 decimal places. I see two options:
- Either depend on older openzepplin versions
- Code an own, better TestERC20 with configurable decimals.

Maybe @fedgiac has a suggestion?

### Test Plan
```
REPORT_GAS=1 yarn test test/e2eUserOption.test.ts 
```
and observe the gas estimations from the e2e test.
```
·----------------------------------------|---------------------------|-----------------|-----------------------------·
|          Solc version: 0.8.10          ·  Optimizer enabled: true  ·  Runs: 1000000  ·  Block limit: 12500000 gas  │
·········································|···························|·················|······························
|  Methods                                                                                                           │
····························|············|·············|·············|·················|···············|··············
|  Contract                 ·  Method    ·  Min        ·  Max        ·  Avg            ·  # calls      ·  usd (avg)  │
····························|············|·············|·············|·················|···············|··············
|  CowProtocolToken         ·  transfer  ·      51504  ·      51516  ·          51510  ·            2  ·          -  │
····························|············|·············|·············|·················|···············|··············
|  CowProtocolVirtualToken  ·  claim     ·          -  ·          -  ·         134722  ·            2  ·          -  │
····························|············|·············|·············|·················|···············|··············
|  CowProtocolVirtualToken  ·  swapAll   ·          -  ·          -  ·          88285  ·            2  ·          -  │
····························|············|·············|·············|·················|···············|··············
|  TestERC20                ·  approve   ·      46248  ·      46260  ·          46254  ·            2  ·          -  │
····························|············|·············|·············|·················|···············|··············
|  TestERC20                ·  mint      ·      72858  ·      72870  ·          72864  ·            2  ·          -  │
····························|············|·············|·············|·················|···············|··············
|  Deployments                           ·                                             ·  % of limit   ·             │
·········································|·············|·············|·················|···············|··············
|  CowProtocolToken                      ·          -  ·          -  ·        1756557  ·       14.1 %  ·          -  │
·········································|·············|·············|·················|···············|··············
|  CowProtocolVirtualToken               ·          -  ·          -  ·        2473807  ·       19.8 %  ·          -  │
·········································|·············|·············|·················|···············|··············
|  TestERC20                             ·    2233495  ·    2233507  ·        2233505  ·       17.9 %  ·          -  │
·----------------------------------------|-------------|-------------|-----------------|---------------|-------------·
```