### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/cow-token",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "verify:etherscan": "hardhat etherscan-verify --license LGPL-3.0 --force-license",


### PR DESCRIPTION
PR #18 changed the ABI of the contract. To make it available to the frontend, we should deploy a new version of the package. As soon as this PR is approved and merged, I'll publish a new version.

### Test Plan

<details><summary>Test that the new package can be imported by a fresh project</summary>

```
$ cd /tmp
$ git clone /path/to/cow-token --no-local
$ cd cow-token/
$ yarn install
$ yarn pack
$ cd ..
$ mkdir test-project
$ cd test-project
$ yarn init # use all defaults
$ yarn add ../cow-token/gnosis.pm-cow-token-v1.0.1.tgz 
$ echo 'const { ContractName } = require("@gnosis.pm/cow-token"); console.log(ContractName);' > script.js
$ node script.js # see that there is no error

```
</details>