### PR TITLE
Set token administration address from user input

### DIFF
--- a/src/tasks/ts/safe.ts
+++ b/src/tasks/ts/safe.ts
@@ -100,3 +100,7 @@ export async function deployWithOwners(
   }
   return new Contract(newSafeAddress, GnosisSafe.abi);
 }
+
+export function gnosisSafeAt(address: string): Contract {
+  return new Contract(address, GnosisSafe.abi);
+}


### PR DESCRIPTION
Adds the option to use existing safes when deploying new test tokens.

### Test Plan

See [this](https://rinkeby.etherscan.io/address/0x64F3A9988Af37e8d832194e4A00E4Eb94a91b764#readContract) vToken deployment. Note for example that the community funds target and the investor funds target is the same.
It was deployed with:
```
$ npx hardhat test-deployment --network rinkeby --user-count 10000 --mnemonic "mnemonic..." --cow-dao 0x4da289f0c05EEfEb3F4b39f836a5859c12B891E5 --community-funds-target 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --investor-funds-target 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --team-controller 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --gnosis-dao 0x4da289f0c05EEfEb3F4b39f836a5859c12B891E5
```

You can test the script personally with:
```
$ npx hardhat test-deployment --network rinkeby --user-count 10000 --mnemonic "mnemonic..." --cow-dao 0x4da289f0c05EEfEb3F4b39f836a5859c12B891E5 --community-funds-target 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --investor-funds-target 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --team-controller 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c
```