### PR TITLE
Allow reading claims from CSV for test deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "canonical-weth": "^1.4.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
+    "csv": "^6.0.5",
     "dotenv": "^13.0.1",
     "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/ts/csv.ts
+++ b/src/ts/csv.ts
@@ -1,0 +1,53 @@
+import { createReadStream } from "fs";
+import type { Readable } from "stream";
+
+import { parse } from "csv-parse";
+import { BigNumber } from "ethers";
+
+import { ClaimType, Claim } from "./claim";
+
+// This is the header that is expected from the CSV for the corresponding claim
+// type.
+export const claimLegend = {
+  Airdrop: ClaimType.Airdrop,
+  GnoOption: ClaimType.GnoOption,
+  UserOption: ClaimType.UserOption,
+  Investor: ClaimType.Investor,
+  Team: ClaimType.Team,
+  Advisor: ClaimType.Advisor,
+} as const;
+// The header of the column containing the addresses of the claim owner.
+const accountLegend = "Account";
+
+export async function parseCsv(stream: Readable): Promise<Claim[]> {
+  const result: Claim[] = [];
+
+  const parser = stream.pipe(parse({ columns: true }));
+  for await (const line of parser) {
+    if (!Object.keys(line).includes(accountLegend)) {
+      throw new Error(
+        `Each CSV line must specify an account. Found: ${JSON.stringify(line)}`,
+      );
+    }
+    const account = line[accountLegend];
+    for (const key of Object.keys(line)) {
+      if (Object.keys(claimLegend).includes(key)) {
+        const type = claimLegend[key as keyof typeof claimLegend];
+        const claimableAmount = BigNumber.from(line[key]);
+        if (!claimableAmount.eq(0)) {
+          result.push({
+            account,
+            type,
+            claimableAmount,
+          });
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+export function parseCsvFile(csvPath: string): Promise<Claim[]> {
+  return parseCsv(createReadStream(csvPath));
+}

--- a/src/ts/csv.ts
+++ b/src/ts/csv.ts
@@ -33,7 +33,7 @@ export async function parseCsv(stream: Readable): Promise<Claim[]> {
     for (const key of Object.keys(line)) {
       if (Object.keys(claimLegend).includes(key)) {
         const type = claimLegend[key as keyof typeof claimLegend];
-        const claimableAmount = BigNumber.from(line[key]);
+        const claimableAmount = BigNumber.from(line[key] || "0");
         if (!claimableAmount.eq(0)) {
           result.push({
             account,

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,5 @@
 export * from "./claim";
+export * from "./csv";
 export * from "./deploy";
 export * from "./permit";
 export * from "./token";

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -1,0 +1,77 @@
+import { Readable } from "stream";
+
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+
+import { Claim, ClaimType, parseCsv } from "../src/ts";
+
+describe("CSV parsing", function () {
+  it("parses one claim per line", async function () {
+    const stream = Readable.from(`Account,UserOption,Airdrop
+0x1234,0,1337
+0x5678,42,0`);
+    const expected: Claim[] = [
+      {
+        account: "0x1234",
+        type: ClaimType.Airdrop,
+        claimableAmount: BigNumber.from(1337),
+      },
+      {
+        account: "0x5678",
+        type: ClaimType.UserOption,
+        claimableAmount: BigNumber.from(42),
+      },
+    ];
+    expect(await parseCsv(stream)).to.deep.equal(expected);
+  });
+
+  it("parses multiple claims per line", async function () {
+    const stream = Readable.from(`Account,UserOption,Airdrop
+0x1234,42,1337`);
+    const expected: Claim[] = [
+      {
+        account: "0x1234",
+        type: ClaimType.UserOption,
+        claimableAmount: BigNumber.from(42),
+      },
+      {
+        account: "0x1234",
+        type: ClaimType.Airdrop,
+        claimableAmount: BigNumber.from(1337),
+      },
+    ];
+    expect(await parseCsv(stream)).to.deep.equal(expected);
+  });
+
+  it("ignores unnecessary columns", async function () {
+    const stream = Readable.from(`Account,Comment,Airdrop
+0x1234,this is a comment,1337`);
+    const expected: Claim[] = [
+      {
+        account: "0x1234",
+        type: ClaimType.Airdrop,
+        claimableAmount: BigNumber.from(1337),
+      },
+    ];
+    expect(await parseCsv(stream)).to.deep.equal(expected);
+  });
+
+  it("reads all claim types", async function () {
+    const stream = Readable.from(
+      "Account,Advisor,Airdrop,GnoOption,Investor,Team,UserOption\n0x1234,1,2,3,4,5,6",
+    );
+    const expected: Claim[] = [
+      [ClaimType.Advisor, 1],
+      [ClaimType.Airdrop, 2],
+      [ClaimType.GnoOption, 3],
+      [ClaimType.Investor, 4],
+      [ClaimType.Team, 5],
+      [ClaimType.UserOption, 6],
+    ].map(([type, i]) => ({
+      account: "0x1234",
+      type,
+      claimableAmount: BigNumber.from(i),
+    }));
+    expect(await parseCsv(stream)).to.deep.equal(expected);
+  });
+});

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -74,4 +74,17 @@ describe("CSV parsing", function () {
     }));
     expect(await parseCsv(stream)).to.deep.equal(expected);
   });
+
+  it("regards empty entries as no claim", async function () {
+    const stream = Readable.from(`Account,UserOption,Airdrop
+0x1234,,1337`);
+    const expected: Claim[] = [
+      {
+        account: "0x1234",
+        type: ClaimType.Airdrop,
+        claimableAmount: BigNumber.from(1337),
+      },
+    ];
+    expect(await parseCsv(stream)).to.deep.equal(expected);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,6 +2930,31 @@ crypto-browserify@3.12.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+csv-generate@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/csv-generate/-/csv-generate-4.0.4.tgz#c780c35ec5b23481d7cf37abd147a4fbdf8c94ad"
+  integrity sha512-6/0FOBbF4O+EBSAYsfOXBjIFhyPpfeeeuWEM4XJQhc/6TvDDL9AGFQNPh2SKlFx7VYERBDmZAWnITgaa+z4BJA==
+
+csv-parse@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.0.4.tgz#97e5e654413bcf95f2714ce09bcb2be6de0eb8e3"
+  integrity sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ==
+
+csv-stringify@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.0.5.tgz#3474a4fe784249eb5c91d455f616e1f70961cdc0"
+  integrity sha512-7xpV3uweJCFF/Ssn56l3xsR/k2r3UqszwjEhej9qEn2cCPzyK1WyHCgoUVzBA792x8HbwonNX7CU9XM2K5s5yw==
+
+csv@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/csv/-/csv-6.0.5.tgz#e7823b1d9c8a35d7ec03801e3e80c3fb0d1d5247"
+  integrity sha512-VyII851P4BvzMsXenhtR7g3mARmZ3HvBX16PD85E8IOoxyvNT9e74egbfdkYBj5SGHh1LphCWXeQvskijH+kfg==
+  dependencies:
+    csv-generate "^4.0.4"
+    csv-parse "^5.0.4"
+    csv-stringify "^6.0.5"
+    stream-transform "^3.0.4"
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -8583,6 +8608,11 @@ stream-to-pull-stream@^1.7.1:
   dependencies:
     looper "^3.0.0"
     pull-stream "^3.2.3"
+
+stream-transform@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/stream-transform/-/stream-transform-3.0.4.tgz#aae97911ea3adf2cd25976655ec3201fb714fda8"
+  integrity sha512-g2jbk1hs3GiF3oHZLbR7Fph/PXh/3xHoz/D8aR2oHySE4xVUvNeTGqihhb1vxFjYyu4inqiTfT42g2MHBjjx0g==
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Instead of always generating random claims, allows to specify a CSV claim file that will be used as the list of all claims available in the test deployment.

Note that the plan is to isolate the random claim generation to its own script and use the csv file mode as the only mode of operation of this script. This means that in a future PR all the `if`s introduced in this PR will be removed.

This change requires the [csv npm package](https://www.npmjs.com/package/csv). To my understanding it's a well-known package to manage CSV files.

### Test Plan

New unit tests. Also manual script testing.

First create a file `./claims.csv` with the following content:
```
Account,Airdrop
0x4242424242424242424242424242424242424242,1337
```

Then execute the test deployment script pointing to this file:
```
$ npx hardhat test-deployment --network rinkeby --mnemonic "claim all milk together toward moon swap coin become rich quick guitar" ./claims.csv 
Using deployer 0xe90C3A883c386636192B0199BbDC933a66BDf43c
Reading user claims from file...
Generating Merkle proofs...
Setting up administration addresses...
Generating deploy transactions...
Clearing old files...
Saving generated data to file...
Deploying real token...
Deploying virtual token...
```

Look for example at `output/claims.json` and notice that there is only a single claim, as expected:
```
[{"account":"0x4242424242424242424242424242424242424242","type":0,"claimableAmount":{"type":"BigNumber","hex":"0x0539"},"index":0,"proof":[]}]
```