### PR TITLE
Use withdraw function instead of eth transfers

### DIFF
--- a/test/CowSwapVirtualToken.test.ts
+++ b/test/CowSwapVirtualToken.test.ts
@@ -142,6 +142,7 @@ describe("CowProtocolVirtualToken", () => {
       "stopClaim(address)",
       "swap(uint256)",
       "swapAll()",
+      "withdrawEth()",
     ];
     const goodPublicFunctions = [
       ...erc20TokenFunctions,

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -103,6 +103,7 @@ describe("e2e-tests", () => {
     communityFundsTarget,
     investorFundsTarget,
     teamController,
+    anyAddress,
   ] = waffle.provider.getWallets();
   const initialCowSupply = ethers.utils.parseEther("1000");
 
@@ -225,9 +226,6 @@ describe("e2e-tests", () => {
     const ethToPay = claim.claimableAmount
       .mul(nativeTokenPrice)
       .div(priceDenominator);
-    const ethBalanceOfCommunityFundsTarget = await ethers.provider.getBalance(
-      communityFundsTarget.address,
-    );
     await deploymentData.wethToken
       .connect(deployer)
       .mint(userNotEligible.address, wethBalanceOfUser);
@@ -251,8 +249,8 @@ describe("e2e-tests", () => {
     expect(vCowTokenSupply).to.be.equal(claim.claimableAmount);
 
     expect(
-      await ethers.provider.getBalance(communityFundsTarget.address),
-    ).to.be.equal(ethToPay.add(ethBalanceOfCommunityFundsTarget));
+      await ethers.provider.getBalance(deploymentData.vCowToken.address),
+    ).to.be.equal(ethToPay);
     expect(await deploymentData.vCowToken.balanceOf(user.address)).to.be.equal(
       claim.claimableAmount,
     );
@@ -282,6 +280,18 @@ describe("e2e-tests", () => {
     expect(await deploymentData.vCowToken.balanceOf(user.address)).to.equal(
       claim.claimableAmount.div(2),
     );
+
+    // Withdraw ETH to the community funds.
+    const ethBalanceOfCommunityFundsTarget = await ethers.provider.getBalance(
+      communityFundsTarget.address,
+    );
+    await deploymentData.vCowToken.connect(anyAddress).withdrawEth();
+    expect(
+      await ethers.provider.getBalance(communityFundsTarget.address),
+    ).to.be.equal(ethBalanceOfCommunityFundsTarget.add(ethToPay));
+    expect(
+      await ethers.provider.getBalance(deploymentData.vCowToken.address),
+    ).to.be.equal(0);
   });
 
   it("GNO option: claims the gno option and vest it", async () => {


### PR DESCRIPTION
At the suggestion of our contract auditor, Adam, I removed the ETH transfer on every user claim (so that the paid funds stay on the contract) and introduced a function that can be called by anyone at any time that transfers the contract balance to the community funds target. (This is similar to what is called the "withdrawal pattern".)

This has two advantages compared with the current implementation:
1. The reentrancy risk becomes very limited, making future changes easier, unlike with the current implementation.
2. Claims paid in ETH become cheaper for the user (by about 10%, i.e. 9500 gas less based on the e2e test results; probably more for wallets that don't support access lists).

This PR implements all changes needed to the tests.

### Test Plan

Updated unit tests and e2e test. Note that `yarn coverage` still reports 100% coverage.
