### PR TITLE
Create deploy transaction with only virtual token

### DIFF
--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -10,8 +10,8 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import {
   metadata,
-  prepareRealAndVirtualSafeDeployment,
-  prepareVirtualSafeDeployment,
+  prepareRealAndVirtualDeploymentFromSafe,
+  prepareVirtualDeploymentFromSafe,
   RealTokenDeployParams,
   VirtualTokenDeployParams,
   computeProofs,
@@ -328,7 +328,7 @@ async function generateClaimsAndDeploy(
   let realTokenDeployment: MaybeDeployment;
   let virtualTokenDeployment: Deployment;
   if (cowToken === undefined) {
-    const deployment = await prepareRealAndVirtualSafeDeployment(
+    const deployment = await prepareRealAndVirtualDeploymentFromSafe(
       realTokenDeployParams,
       virtualTokenDeployParams,
       MultiSendDeployment.networkAddresses[chainId],
@@ -348,7 +348,7 @@ async function generateClaimsAndDeploy(
     );
   } else {
     {
-      const deployment = await prepareVirtualSafeDeployment(
+      const deployment = await prepareVirtualDeploymentFromSafe(
         { ...virtualTokenDeployParams, realToken: cowToken },
         ethers,
         salt,

--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 
+import { MetaTransaction } from "@gnosis.pm/safe-contracts";
 import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20Metadata.json";
 import { expect } from "chai";
 import { BigNumber, Contract, utils } from "ethers";
@@ -9,7 +10,8 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import {
   metadata,
-  prepareSafeDeployment,
+  prepareRealAndVirtualSafeDeployment,
+  prepareVirtualSafeDeployment,
   RealTokenDeployParams,
   VirtualTokenDeployParams,
   computeProofs,
@@ -68,6 +70,7 @@ interface DeployTaskArgs {
   communityFundsTarget?: string;
   investorFundsTarget?: string;
   teamController?: string;
+  cowToken?: string;
 }
 interface CleanArgs {
   claimCsv: string;
@@ -84,11 +87,20 @@ interface CleanArgs {
   communityFundsTargetAddress: string | undefined;
   investorFundsTargetAddress: string | undefined;
   teamControllerAddress: string | undefined;
+  cowToken: string | undefined;
 }
 
 interface Token {
   decimals: number;
   instance: Contract;
+}
+
+interface MaybeDeployment {
+  address: string;
+  transaction: MetaTransaction | null;
+}
+interface Deployment extends MaybeDeployment {
+  transaction: MetaTransaction;
 }
 
 async function parseArgs(
@@ -166,6 +178,7 @@ async function parseArgs(
     communityFundsTargetAddress: checksummedAddress(args.communityFundsTarget),
     investorFundsTargetAddress: checksummedAddress(args.investorFundsTarget),
     teamControllerAddress: checksummedAddress(args.teamController),
+    cowToken: checksummedAddress(args.cowToken),
   };
 }
 
@@ -225,6 +238,10 @@ const setupTestDeploymentTask: () => void = () => {
       "teamController",
       "The address that controls team claims. If left out, a dedicated Gnosis Safe owned by the deployer will be deployed for this purpose.",
     )
+    .addOptionalParam(
+      "cowToken",
+      "The virtual token will point to this address for the cow token. If left out, the real token will be deployed by this script.",
+    )
     .setAction(async (args, hre) => {
       await generateClaimsAndDeploy(await parseArgs(args, hre), hre);
     });
@@ -246,6 +263,7 @@ async function generateClaimsAndDeploy(
     communityFundsTargetAddress,
     investorFundsTargetAddress,
     teamControllerAddress,
+    cowToken,
   }: CleanArgs,
   hre: HardhatRuntimeEnvironment,
 ) {
@@ -307,21 +325,44 @@ async function generateClaimsAndDeploy(
     };
 
   console.log("Generating deploy transactions...");
-  const {
-    realTokenDeployTransaction,
-    virtualTokenDeployTransaction,
-    realTokenAddress,
-    virtualTokenAddress,
-  } = await prepareSafeDeployment(
-    realTokenDeployParams,
-    virtualTokenDeployParams,
-    MultiSendDeployment.networkAddresses[chainId],
-    ethers,
-    salt,
-  );
-
-  expect(await ethers.provider.getCode(realTokenAddress)).to.equal("0x");
-  expect(await ethers.provider.getCode(virtualTokenAddress)).to.equal("0x");
+  let realTokenDeployment: MaybeDeployment;
+  let virtualTokenDeployment: Deployment;
+  if (cowToken === undefined) {
+    const deployment = await prepareRealAndVirtualSafeDeployment(
+      realTokenDeployParams,
+      virtualTokenDeployParams,
+      MultiSendDeployment.networkAddresses[chainId],
+      ethers,
+      salt,
+    );
+    realTokenDeployment = {
+      address: deployment.realTokenAddress,
+      transaction: deployment.realTokenDeployTransaction,
+    };
+    virtualTokenDeployment = {
+      address: deployment.virtualTokenAddress,
+      transaction: deployment.virtualTokenDeployTransaction,
+    };
+    expect(await ethers.provider.getCode(realTokenDeployment.address)).to.equal(
+      "0x",
+    );
+  } else {
+    {
+      const deployment = await prepareVirtualSafeDeployment(
+        { ...virtualTokenDeployParams, realToken: cowToken },
+        ethers,
+        salt,
+      );
+      realTokenDeployment = { address: cowToken, transaction: null };
+      virtualTokenDeployment = {
+        address: deployment.virtualTokenAddress,
+        transaction: deployment.virtualTokenDeployTransaction,
+      };
+    }
+  }
+  expect(
+    await ethers.provider.getCode(virtualTokenDeployment.address),
+  ).to.equal("0x");
 
   console.log("Clearing old files...");
   await fs.rm(`${OUTPUT_FOLDER}/claims.json`, { recursive: true, force: true });
@@ -337,34 +378,40 @@ async function generateClaimsAndDeploy(
   await fs.writeFile(
     `${OUTPUT_FOLDER}/params.json`,
     JSON.stringify({
-      realTokenAddress,
-      virtualTokenAddress,
+      realTokenAddress: realTokenDeployment.address,
+      virtualTokenAddress: virtualTokenDeployment.address,
       ...realTokenDeployParams,
       ...virtualTokenDeployParams,
     }),
   );
   await splitClaimsAndSaveToFolder(claimsWithProof, OUTPUT_FOLDER);
 
-  console.log("Deploying real token...");
-  const deploymentReal = await execSafeTransaction(
-    gnosisDao.connect(deployer),
-    realTokenDeployTransaction,
-    [deployer],
-  );
-  await expect(deploymentReal).to.emit(
-    gnosisDao.connect(ethers.provider),
-    "ExecutionSuccess",
-  );
-  expect(await ethers.provider.getCode(realTokenAddress)).not.to.equal("0x");
+  if (realTokenDeployment.transaction !== null) {
+    console.log("Deploying real token...");
+    const deploymentReal = await execSafeTransaction(
+      gnosisDao.connect(deployer),
+      realTokenDeployment.transaction,
+      [deployer],
+    );
+    await expect(deploymentReal).to.emit(
+      gnosisDao.connect(ethers.provider),
+      "ExecutionSuccess",
+    );
+    expect(
+      await ethers.provider.getCode(realTokenDeployment.address),
+    ).not.to.equal("0x");
+  }
 
   console.log("Deploying virtual token...");
   const deploymentVirtual = await execSafeTransaction(
     gnosisDao.connect(deployer),
-    virtualTokenDeployTransaction,
+    virtualTokenDeployment.transaction,
     [deployer],
   );
   await expect(deploymentVirtual).to.emit(gnosisDao, "ExecutionSuccess");
-  expect(await ethers.provider.getCode(virtualTokenAddress)).not.to.equal("0x");
+  expect(
+    await ethers.provider.getCode(virtualTokenDeployment.address),
+  ).not.to.equal("0x");
 }
 
 export { setupTestDeploymentTask };

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -209,7 +209,7 @@ async function getDeploymentTransaction<T extends ContractName>(
   return { safeTransaction, address };
 }
 
-export async function prepareRealAndVirtualSafeDeployment(
+export async function prepareRealAndVirtualDeploymentFromSafe(
   realTokenDeployParams: RealTokenDeployParams,
   virtualTokenDeployParams: Omit<VirtualTokenDeployParams, "realToken">,
   multisendAddress: string,
@@ -233,7 +233,7 @@ export async function prepareRealAndVirtualSafeDeployment(
   );
 
   const { virtualTokenDeployTransaction, virtualTokenAddress } =
-    await prepareVirtualSafeDeployment(
+    await prepareVirtualDeploymentFromSafe(
       { ...virtualTokenDeployParams, realToken: realTokenAddress },
       ethers,
       salt,
@@ -251,7 +251,7 @@ export async function prepareRealAndVirtualSafeDeployment(
   };
 }
 
-export async function prepareVirtualSafeDeployment(
+export async function prepareVirtualDeploymentFromSafe(
   virtualTokenDeployParams: VirtualTokenDeployParams,
   ethers: HardhatEthersHelpers,
   salt?: string,

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -209,7 +209,7 @@ async function getDeploymentTransaction<T extends ContractName>(
   return { safeTransaction, address };
 }
 
-export async function prepareSafeDeployment(
+export async function prepareRealAndVirtualSafeDeployment(
   realTokenDeployParams: RealTokenDeployParams,
   virtualTokenDeployParams: Omit<VirtualTokenDeployParams, "realToken">,
   multisendAddress: string,
@@ -222,31 +222,55 @@ export async function prepareSafeDeployment(
   realTokenAddress: string;
   virtualTokenAddress: string;
 }> {
-  const { safeTransaction: realTokenDeployment, address: realTokenAddress } =
-    await getDeploymentTransaction(
-      ContractName.RealToken,
-      realTokenDeployParams,
+  const {
+    safeTransaction: realTokenDeployTransaction,
+    address: realTokenAddress,
+  } = await getDeploymentTransaction(
+    ContractName.RealToken,
+    realTokenDeployParams,
+    ethers,
+    salt,
+  );
+
+  const { virtualTokenDeployTransaction, virtualTokenAddress } =
+    await prepareVirtualSafeDeployment(
+      { ...virtualTokenDeployParams, realToken: realTokenAddress },
       ethers,
       salt,
     );
+
+  return {
+    realTokenDeployTransaction,
+    virtualTokenDeployTransaction,
+    deployTransaction: multisend(
+      [realTokenDeployTransaction, virtualTokenDeployTransaction],
+      multisendAddress,
+    ),
+    realTokenAddress,
+    virtualTokenAddress,
+  };
+}
+
+export async function prepareVirtualSafeDeployment(
+  virtualTokenDeployParams: VirtualTokenDeployParams,
+  ethers: HardhatEthersHelpers,
+  salt?: string,
+): Promise<{
+  virtualTokenDeployTransaction: MetaTransaction;
+  virtualTokenAddress: string;
+}> {
   const {
     safeTransaction: virtualTokenDeployment,
     address: virtualTokenAddress,
   } = await getDeploymentTransaction(
     ContractName.VirtualToken,
-    { ...virtualTokenDeployParams, realToken: realTokenAddress },
+    virtualTokenDeployParams,
     ethers,
     salt,
   );
 
   return {
-    realTokenDeployTransaction: realTokenDeployment,
     virtualTokenDeployTransaction: virtualTokenDeployment,
-    deployTransaction: multisend(
-      [realTokenDeployment, virtualTokenDeployment],
-      multisendAddress,
-    ),
-    realTokenAddress,
     virtualTokenAddress,
   };
 }

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -6,8 +6,8 @@ import hre, { ethers, waffle } from "hardhat";
 import { execSafeTransaction } from "../src/tasks/ts/safe";
 import {
   metadata,
-  prepareRealAndVirtualSafeDeployment,
-  prepareVirtualSafeDeployment,
+  prepareRealAndVirtualDeploymentFromSafe,
+  prepareVirtualDeploymentFromSafe,
   ContractName,
   RealTokenDeployParams,
   VirtualTokenDeployParams,
@@ -85,7 +85,7 @@ describe("deployment", () => {
       virtualTokenDeployTransaction,
       realTokenAddress,
       virtualTokenAddress,
-    } = await prepareRealAndVirtualSafeDeployment(
+    } = await prepareRealAndVirtualDeploymentFromSafe(
       realTokenDeployParams,
       virtualTokenDeployParams,
       safeManager.multisend.address,
@@ -131,7 +131,7 @@ describe("deployment", () => {
   it("performed from a Gnosis Safe with an existing real token address", async () => {
     const realTokenAddress = "0x" + "1337".repeat(10);
     const { virtualTokenDeployTransaction, virtualTokenAddress } =
-      await prepareVirtualSafeDeployment(
+      await prepareVirtualDeploymentFromSafe(
         { ...virtualTokenDeployParams, realToken: realTokenAddress },
         hre.ethers,
       );
@@ -160,7 +160,7 @@ describe("deployment", () => {
     skipOnCoverage.call(this);
 
     const { realTokenDeployTransaction, virtualTokenDeployTransaction } =
-      await prepareRealAndVirtualSafeDeployment(
+      await prepareRealAndVirtualDeploymentFromSafe(
         realTokenDeployParams,
         virtualTokenDeployParams,
         safeManager.multisend.address,
@@ -191,7 +191,7 @@ describe("deployment", () => {
         virtualTokenDeployTransaction,
         realTokenAddress,
         virtualTokenAddress,
-      } = await prepareRealAndVirtualSafeDeployment(
+      } = await prepareRealAndVirtualDeploymentFromSafe(
         realTokenDeployParams,
         virtualTokenDeployParams,
         safeManager.multisend.address,


### PR DESCRIPTION
Use the script to deploy the virtual token without deploying the real token first. This is useful to test on xDai, where the real token address will be the bridged COW token address.

### Test Plan

New unit tests.
Also, test the script (after creating a test CSV file, see readme):
```
$ npx hardhat test-deployment --network rinkeby --cow-token 0x4242424242424242424242424242424242424242 ./output/test-claims/claims.csv

```

Note that in the file `./output/test-deployment/params.json` there is an entry `"realTokenAddress":"0x4242424242424242424242424242424242424242"`. Also check an [example deployment on Rinkeby](https://rinkeby.etherscan.io/address/0x54E0DD158264e9CEB9D6C8939e7BB2cA3a543C2E#readContract) and see that the function `cowToken` returns `0x42..42`.