### PR TITLE
Make virtual token deployment non-deterministic

### DIFF
--- a/src/tasks/ts/safe.ts
+++ b/src/tasks/ts/safe.ts
@@ -7,6 +7,7 @@ import {
 } from "@gnosis.pm/safe-contracts";
 import GnosisSafe from "@gnosis.pm/safe-contracts/build/artifacts/contracts/GnosisSafe.sol/GnosisSafe.json";
 import GnosisSafeProxyFactory from "@gnosis.pm/safe-contracts/build/artifacts/contracts/proxies/GnosisSafeProxyFactory.sol/GnosisSafeProxyFactory.json";
+import CreateCallDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/create_call.json";
 import GnosisSafeDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/gnosis_safe.json";
 import MultiSendDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/multi_send_call_only.json";
 import GnosisSafeProxyFactoryDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/proxy_factory.json";
@@ -14,12 +15,13 @@ import { constants, Contract, ContractReceipt, Signer, Wallet } from "ethers";
 import { Interface } from "ethers/lib/utils";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-export { MultiSendDeployment };
+export { MultiSendDeployment, CreateCallDeployment };
 
 export type SupportedChainId =
   keyof typeof GnosisSafeProxyFactoryDeployment.networkAddresses &
     keyof typeof GnosisSafeDeployment.networkAddresses &
-    keyof typeof MultiSendDeployment.networkAddresses;
+    keyof typeof MultiSendDeployment.networkAddresses &
+    keyof typeof CreateCallDeployment.networkAddresses;
 
 export function isChainIdSupported(
   chainId: string,
@@ -29,7 +31,8 @@ export function isChainIdSupported(
       chainId,
     ) &&
     Object.keys(GnosisSafeDeployment.networkAddresses).includes(chainId) &&
-    Object.keys(MultiSendDeployment.networkAddresses).includes(chainId)
+    Object.keys(MultiSendDeployment.networkAddresses).includes(chainId) &&
+    Object.keys(CreateCallDeployment.networkAddresses).includes(chainId)
   );
 }
 

--- a/src/ts/deploy/safe.ts
+++ b/src/ts/deploy/safe.ts
@@ -1,11 +1,15 @@
+import type { TransactionResponse } from "@ethersproject/abstract-provider";
 import { MetaTransaction, encodeMultiSend } from "@gnosis.pm/safe-contracts";
+import CreateCall from "@gnosis.pm/safe-contracts/build/artifacts/contracts/libraries/CreateCall.sol/CreateCall.json";
 import MultiSend from "@gnosis.pm/safe-contracts/build/artifacts/contracts/libraries/MultiSend.sol/MultiSend.json";
-import { Contract } from "ethers";
+import { BytesLike, constants, Contract, utils } from "ethers";
 
 export enum SafeOperation {
   Call = 0,
   DelegateCall = 1,
 }
+
+const createCallIface = new utils.Interface(CreateCall.abi);
 
 export function multisend(
   transactions: MetaTransaction[],
@@ -21,4 +25,34 @@ export function multisend(
     operation: SafeOperation.DelegateCall,
     data,
   };
+}
+
+export function createTransaction(
+  deploymentData: BytesLike,
+  createCallAddress: string,
+) {
+  const createCall = new Contract(createCallAddress, CreateCall.abi);
+  const value = constants.Zero;
+  const data = createCall.interface.encodeFunctionData("performCreate", [
+    value,
+    deploymentData,
+  ]);
+  return {
+    to: createCall.address,
+    value,
+    operation: SafeOperation.Call,
+    data,
+  };
+}
+
+export async function contractsCreatedWithCreateCall(
+  response: TransactionResponse,
+  createCallAddress: string,
+): Promise<string[]> {
+  const receipt = await response.wait();
+  const creationEvents = receipt.logs
+    .filter(({ address }) => address === createCallAddress)
+    .map((log) => createCallIface.parseLog(log))
+    .filter(({ name }) => name === "ContractCreation");
+  return creationEvents.map(({ args }) => args.newContract);
 }

--- a/test/safe.ts
+++ b/test/safe.ts
@@ -1,4 +1,5 @@
 import GnosisSafe from "@gnosis.pm/safe-contracts/build/artifacts/contracts/GnosisSafe.sol/GnosisSafe.json";
+import CreateCall from "@gnosis.pm/safe-contracts/build/artifacts/contracts/libraries/CreateCall.sol/CreateCall.json";
 import MultiSend from "@gnosis.pm/safe-contracts/build/artifacts/contracts/libraries/MultiSend.sol/MultiSend.json";
 import GnosisSafeProxyFactory from "@gnosis.pm/safe-contracts/build/artifacts/contracts/proxies/GnosisSafeProxyFactory.sol/GnosisSafeProxyFactory.json";
 import { Signer, Contract } from "ethers";
@@ -10,6 +11,7 @@ export class GnosisSafeManager {
     public readonly singleton: Contract,
     public readonly multisend: Contract,
     public readonly proxyFactory: Contract,
+    public readonly createCall: Contract,
   ) {}
 
   public static async init(deployer: Signer): Promise<GnosisSafeManager> {
@@ -19,7 +21,14 @@ export class GnosisSafeManager {
       GnosisSafeProxyFactory,
     );
     const multisend = await waffle.deployContract(deployer, MultiSend);
-    return new GnosisSafeManager(deployer, singleton, multisend, proxyFactory);
+    const createCall = await waffle.deployContract(deployer, CreateCall);
+    return new GnosisSafeManager(
+      deployer,
+      singleton,
+      multisend,
+      proxyFactory,
+      createCall,
+    );
   }
 
   public async newSafe(owners: string[], threshold: number): Promise<Contract> {


### PR DESCRIPTION
The virtual token deployment is currently deterministic. Also, the starting time for vesting and for claiming depends on the contract deployment time.
This PR makes the virtual contract deployment non-deterministic to avoid this issue. The address of the virtual token will only be known after the virtual token deployment transaction will be executed, and cannot be deployed in advance.
The real token is still deterministic so that we can generate vanity addresses for this token. However, an earlier deployment would not affect any of the functionalities of the token.

### Test Plan

Updated unit tests. Also, try out the changes in the test deployment script:
```
npx hardhat test-deployment --network rinkeby ./output/test-claims/claims.csv 
```

Check out that the file `./output/test-deployment/params.json` looks right (has both real and virtual token addresses, the virtual token points to a real contract).

From the contract address on etherscan, look at the deployment transaction logs and see that there was a `ContractCreation` event ([example](https://rinkeby.etherscan.io/tx/0x02eb263b92b3db8752f1c8e3c8df992df9f8851abac183835469b6c2e80d1346#eventlog)).
