### PR TITLE
Introducing a new initialTokenHolder for the real cowToken

### DIFF
--- a/src/contracts/CowProtocolToken.sol
+++ b/src/contracts/CowProtocolToken.sol
@@ -11,8 +11,18 @@ contract CowProtocolToken is InflationaryToken, StorageAccessible {
     string private constant ERC20_SYMBOL = "COW";
     string private constant ERC20_NAME = "CoW Protocol Token";
 
-    constructor(address cowDao, uint256 totalSupply)
-        InflationaryToken(cowDao, totalSupply, ERC20_NAME, ERC20_SYMBOL)
+    constructor(
+        address initialTokenHolder,
+        address cowDao,
+        uint256 totalSupply
+    )
+        InflationaryToken(
+            initialTokenHolder,
+            cowDao,
+            totalSupply,
+            ERC20_NAME,
+            ERC20_SYMBOL
+        )
     // solhint-disable-next-line no-empty-blocks
     {
 

--- a/src/contracts/mixins/InflationaryToken.sol
+++ b/src/contracts/mixins/InflationaryToken.sol
@@ -32,14 +32,13 @@ contract InflationaryToken is ERC20, ERC20Permit {
     }
 
     constructor(
+        address initialTokenHolder,
         address _cowDao,
         uint256 totalSupply,
         string memory erc20Name,
         string memory erc20Symbol
     ) ERC20(erc20Name, erc20Symbol) ERC20Permit(erc20Name) {
-        // The CowDao is responsible for handling the initial distribution of
-        // the token.
-        _mint(_cowDao, totalSupply);
+        _mint(initialTokenHolder, totalSupply);
         cowDao = _cowDao;
         // solhint-disable-next-line not-rely-on-time
         timestampLastMinting = block.timestamp;

--- a/src/tasks/test-deployment.ts
+++ b/src/tasks/test-deployment.ts
@@ -300,6 +300,7 @@ async function generateClaimsAndDeploy(
   const teamController = teamControllerAddress ?? (await deploySafe()).address;
 
   const realTokenDeployParams: RealTokenDeployParams = {
+    initialTokenHolder: cowDao,
     totalSupply,
     cowDao,
   };

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -43,6 +43,7 @@ export interface DeterministicDeploymentInfo {
 }
 
 export interface RealTokenDeployParams {
+  initialTokenHolder: string;
   cowDao: string;
   totalSupply: BigNumberish;
 }
@@ -70,7 +71,7 @@ export interface DeployParams {
   [ContractName.VirtualToken]: VirtualTokenDeployParams;
 }
 export type ContructorInput = {
-  [ContractName.RealToken]: [string, BigNumberish];
+  [ContractName.RealToken]: [string, string, BigNumberish];
   [ContractName.VirtualToken]: [
     string,
     string,
@@ -95,9 +96,10 @@ export function constructorInput<T extends ContractName>(
   // by TS.
   switch (contract) {
     case ContractName.RealToken: {
-      const { cowDao, totalSupply } =
+      const { initialTokenHolder, cowDao, totalSupply } =
         params as DeployParams[ContractName.RealToken];
       const result: ContructorInput[ContractName.RealToken] = [
+        initialTokenHolder,
         cowDao,
         totalSupply,
       ];
@@ -278,7 +280,17 @@ export async function prepareVirtualDeploymentFromSafe(
 export async function getDeployArgsFromRealToken(
   realToken: Contract,
 ): Promise<Omit<RealTokenDeployParams, "totalSupply">> {
+  const filterMintingTransfers = realToken.filters.Transfer(
+    "0x0000000000000000000000000000000000000000",
+    null,
+    null,
+  );
+  const logs = await realToken.queryFilter(filterMintingTransfers, 0, "latest");
+  const events = logs.map((log) => realToken.interface.parseLog(log));
+  // initialTokenHolder is the receiver of the first mint transfer
+  const initialTokenHolder = events[0].args.to;
   return {
+    initialTokenHolder,
     cowDao: await realToken.cowDao(),
   };
 }

--- a/test/CowSwapToken.test.ts
+++ b/test/CowSwapToken.test.ts
@@ -21,7 +21,7 @@ describe("CowProtocolToken", () => {
       ContractName.RealToken,
     );
     const constructorParams: RealTokenDeployParams = {
-      initialTokenHolder: cowDao.address,
+      initialTokenHolder: "0x" + "42".repeat(42),
       cowDao: cowDao.address,
       totalSupply,
     };

--- a/test/CowSwapToken.test.ts
+++ b/test/CowSwapToken.test.ts
@@ -21,6 +21,7 @@ describe("CowProtocolToken", () => {
       ContractName.RealToken,
     );
     const constructorParams: RealTokenDeployParams = {
+      initialTokenHolder: cowDao.address,
       cowDao: cowDao.address,
       totalSupply,
     };

--- a/test/CowSwapToken.test.ts
+++ b/test/CowSwapToken.test.ts
@@ -21,7 +21,7 @@ describe("CowProtocolToken", () => {
       ContractName.RealToken,
     );
     const constructorParams: RealTokenDeployParams = {
-      initialTokenHolder: "0x" + "42".repeat(42),
+      initialTokenHolder: "0x" + "42".repeat(20),
       cowDao: cowDao.address,
       totalSupply,
     };

--- a/test/InflationaryToken.test.ts
+++ b/test/InflationaryToken.test.ts
@@ -13,6 +13,7 @@ describe("InflationaryToken", () => {
   let cowDao: Wallet;
   let user: Wallet;
   let deployer: Wallet;
+  let initialTokenHolder: Wallet;
 
   const totalSupply = ethers.utils.parseUnits("31337", 18);
   const erc20Name = "erc20Name";
@@ -23,11 +24,13 @@ describe("InflationaryToken", () => {
   let oneYearAfterDeployment: number;
 
   beforeEach(async () => {
-    [deployer, cowDao, user] = await waffle.provider.getWallets();
+    [deployer, initialTokenHolder, cowDao, user] =
+      await waffle.provider.getWallets();
     const InflationaryToken = await ethers.getContractFactory(
       "InflationaryToken",
     );
     token = await InflationaryToken.connect(deployer).deploy(
+      initialTokenHolder.address,
       cowDao.address,
       totalSupply,
       erc20Name,
@@ -53,8 +56,10 @@ describe("InflationaryToken", () => {
     expect(await token.totalSupply()).to.equal(totalSupply);
   });
 
-  it("sends total supply to cow dao", async () => {
-    expect(await token.balanceOf(cowDao.address)).to.equal(totalSupply);
+  it("sends total supply to initialTokenHolder dao", async () => {
+    expect(await token.balanceOf(initialTokenHolder.address)).to.equal(
+      totalSupply,
+    );
   });
 
   it("sets the minter role for cowDao", async function () {
@@ -157,6 +162,7 @@ describe("InflationaryToken", () => {
         "InflationaryToken",
       );
       token = await InflationaryToken.connect(deployer).deploy(
+        cowDao.address,
         cowDao.address,
         totalSupply,
         erc20Name,

--- a/test/InflationaryToken.test.ts
+++ b/test/InflationaryToken.test.ts
@@ -162,7 +162,7 @@ describe("InflationaryToken", () => {
         "InflationaryToken",
       );
       token = await InflationaryToken.connect(deployer).deploy(
-        cowDao.address,
+        initialTokenHolder.address,
         cowDao.address,
         totalSupply,
         erc20Name,

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -26,6 +26,7 @@ describe("deployment", () => {
   let safe: Contract;
 
   const realTokenDeployParams: RealTokenDeployParams = {
+    initialTokenHolder: utils.getAddress("0x" + "0da00000" + "42".repeat(16)),
     totalSupply,
     cowDao: utils.getAddress("0x" + "ca1f0000" + "42".repeat(16)),
   };
@@ -218,8 +219,12 @@ describe("deployment", () => {
       });
 
       it("cowDao", async function () {
+        expect(await realToken.cowDao()).to.equal(realTokenDeployParams.cowDao);
+      });
+
+      it("initialTokenHolder", async function () {
         expect(
-          await realToken.balanceOf(realTokenDeployParams.cowDao),
+          await realToken.balanceOf(realTokenDeployParams.initialTokenHolder),
         ).not.to.equal(0);
       });
     });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -27,6 +27,7 @@ interface DeploymentData {
   deploymentTimestamp: number;
 }
 interface DeploymentParameters {
+  initialTokenHolder: Wallet;
   deployer: Wallet;
   cowDao: Wallet;
   investorFundsTarget: Wallet;
@@ -51,7 +52,7 @@ async function standardDeployment(
   // Deploying of the CowToken
   const CowSwapToken = await ethers.getContractFactory(ContractName.RealToken);
   const realTokenDeploymentParams: RealTokenDeployParams = {
-    initialTokenHolder: deploymentParameters.cowDao.address,
+    initialTokenHolder: deploymentParameters.initialTokenHolder.address,
     cowDao: deploymentParameters.cowDao.address,
     totalSupply: deploymentParameters.initialCowSupply,
   };
@@ -100,6 +101,7 @@ describe("e2e-tests", () => {
     deployer,
     user,
     userNotEligible,
+    initialTokenHolder,
     cowDao,
     communityFundsTarget,
     investorFundsTarget,
@@ -135,6 +137,7 @@ describe("e2e-tests", () => {
     claims = provenClaims.claims;
 
     const deploymentParameters: DeploymentParameters = {
+      initialTokenHolder,
       deployer,
       cowDao,
       communityFundsTarget,
@@ -179,7 +182,7 @@ describe("e2e-tests", () => {
 
     // Send cowTokens to the vCowToken
     await deploymentData.cowToken
-      .connect(cowDao)
+      .connect(initialTokenHolder)
       .transfer(deploymentData.vCowToken.address, initialCowSupply);
 
     // Perform a swapAll
@@ -211,6 +214,7 @@ describe("e2e-tests", () => {
     claims = provenClaims.claims;
 
     const deploymentParameters: DeploymentParameters = {
+      initialTokenHolder,
       deployer,
       cowDao,
       communityFundsTarget,
@@ -261,7 +265,7 @@ describe("e2e-tests", () => {
 
     // Send cowTokens to the vCowToken
     await deploymentData.cowToken
-      .connect(cowDao)
+      .connect(initialTokenHolder)
       .transfer(deploymentData.vCowToken.address, claim.claimableAmount.div(2));
 
     // Perform a swapAll
@@ -305,6 +309,7 @@ describe("e2e-tests", () => {
     provenClaims = computeProofs([claim]);
     claims = provenClaims.claims;
     const deploymentParameters: DeploymentParameters = {
+      initialTokenHolder,
       deployer,
       cowDao,
       communityFundsTarget,
@@ -347,7 +352,7 @@ describe("e2e-tests", () => {
 
     // Send cowTokens to the vCowToken
     await deploymentData.cowToken
-      .connect(cowDao)
+      .connect(initialTokenHolder)
       .transfer(deploymentData.vCowToken.address, initialCowSupply);
 
     // Perform a swapAll

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -51,6 +51,7 @@ async function standardDeployment(
   // Deploying of the CowToken
   const CowSwapToken = await ethers.getContractFactory(ContractName.RealToken);
   const realTokenDeploymentParams: RealTokenDeployParams = {
+    initialTokenHolder: deploymentParameters.cowDao.address,
     cowDao: deploymentParameters.cowDao.address,
     totalSupply: deploymentParameters.initialCowSupply,
   };


### PR DESCRIPTION
Description: 
Allows to mint the initial supply of cowTokens to another address than the cowDAO.

Background
This small change is made, such that the deployment is easier: For the deployment, we need to send some tokens into the omni bridge for the deployment on gnosis chain. If all the initialTokenSupply goes to the cowDAO, sending them from the cowdao to the omni bridge is complicated - one has to deal with a lot of signatures . Hence, we will mint the initial supply to the GnosisDAO and then send it immediately to the cowDAO + omniBridge from there.


### Test Plan

_<Explain how you and a reviewer have/intend to test this change>_
