### PR TITLE
Add @types/node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^9.1.0",
+    "@types/node": "^17.0.10",
     "@types/yargs": "^17.0.7",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.37.tgz#abb38afa9d6e8a2f627a8cb52290b3c80fbe61ed"
   integrity sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==
 
+"@types/node@^17.0.10":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.10.tgz#616f16e9d3a2a3d618136b1be244315d95bd7cab"
+  integrity sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==
+
 "@types/node@^8.0.0":
   version "8.10.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"


### PR DESCRIPTION
Fixes [this warning](https://github.com/gnosis/cow-token/runs/4914741616?check_suite_focus=true#step:6:8) when running `yarn install`:
```
warning " > ts-node@10.4.0" has unmet peer dependency "@types/node@*".
```

It seems that ts-node uses the types in `@types/node` in order to work (as they are required as a peer dependency). It is currently using the types in a (possibly different) version of `@types/node` that was transitively installed by another of our dependencies. With the changes in this PR we don't rely on this anymore but we explicitly install the types.

### Test Plan

See warning log line [missing from CI](https://github.com/gnosis/cow-token/runs/4920923946#step:6:1).