### PR TITLE
Test sending ETH to safe before its creation

### DIFF
--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -177,7 +177,7 @@ describe("Gnosis Safe creation", function () {
 
       await creator.sendTransaction({ to, data });
       const safe = gnosisSafeAt(address).connect(executor);
-      const receiver = "0x" + "42".repeat(20);
+      const receiver = "0x" + "2142".repeat(10);
       expect(await ethers.provider.getBalance(receiver)).to.equal(
         constants.Zero,
       );


### PR DESCRIPTION
If the xDAI bridge fails to send transactions to xDAI or sends them in the incorrect order, a deterministically deployed Gnosis Safe might receive ERC20 tokens or ETH before its creation. This test simulates this scenario.
As all ERC20 balances are only handled in the ERC20 token contracts themselves, there is no corresponding tests for ERC20 tokens.

### Test Plan

Is a test.
