### PR TITLE
Fix name of tag committer

### DIFF
--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -24,7 +24,7 @@ fail_if_unset AWS_SECRET_ACCESS_KEY
 fail_if_unset AWS_REGION
 
 git_username="GitHub Actions"
-git_useremail="GitHub-Actions@GPv2-contracts"
+git_useremail="GitHub-Actions@CoW-Token"
 
 package_name="$(jq --raw-output .name ./package.json)"
 version="$(jq --raw-output .version ./package.json)"


### PR DESCRIPTION
The NPM publish script was copied from [gnosis/gp-v2-token](https://github.com/gnosis/gp-v2-contracts).
The name of the git user who creates the tag has been left unchanged to `GitHub-Actions@GPv2-contracts`.
This PR fixes that.

We can see the effects of this issue by running:
```
$ git show v1.0.1
tag v1.0.1
Tagger: GitHub Actions <GitHub-Actions@GPv2-contracts>
Date:   Fri Jan 14 15:52:02 2022 +0000

Version 1.0.1
[...]
```

### Test Plan

Untested, we can check the next time we create a new version.