### PR TITLE
Format vendored contracts

### DIFF
--- a/src/contracts/vendored/mixins/BridgedTokensRegistry.sol
+++ b/src/contracts/vendored/mixins/BridgedTokensRegistry.sol
@@ -10,15 +10,25 @@ import "./EternalStorage.sol";
  * @dev Functionality for keeping track of registered bridged token pairs.
  */
 contract BridgedTokensRegistry is EternalStorage {
-    event NewTokenRegistered(address indexed nativeToken, address indexed bridgedToken);
+    event NewTokenRegistered(
+        address indexed nativeToken,
+        address indexed bridgedToken
+    );
 
     /**
      * @dev Retrieves address of the bridged token contract associated with a specific native token contract on the other side.
      * @param _nativeToken address of the native token contract on the other side.
      * @return address of the deployed bridged token contract.
      */
-    function bridgedTokenAddress(address _nativeToken) public view returns (address) {
-        return addressStorage[keccak256(abi.encodePacked("homeTokenAddress", _nativeToken))];
+    function bridgedTokenAddress(address _nativeToken)
+        public
+        view
+        returns (address)
+    {
+        return
+            addressStorage[
+                keccak256(abi.encodePacked("homeTokenAddress", _nativeToken))
+            ];
     }
 
     /**
@@ -26,8 +36,17 @@ contract BridgedTokensRegistry is EternalStorage {
      * @param _bridgedToken address of the created bridged token contract on this side.
      * @return address of the native token contract on the other side of the bridge.
      */
-    function nativeTokenAddress(address _bridgedToken) public view returns (address) {
-        return addressStorage[keccak256(abi.encodePacked("foreignTokenAddress", _bridgedToken))];
+    function nativeTokenAddress(address _bridgedToken)
+        public
+        view
+        returns (address)
+    {
+        return
+            addressStorage[
+                keccak256(
+                    abi.encodePacked("foreignTokenAddress", _bridgedToken)
+                )
+            ];
     }
 
     /**
@@ -35,9 +54,15 @@ contract BridgedTokensRegistry is EternalStorage {
      * @param _nativeToken address of the native token contract on the other side.
      * @param _bridgedToken address of the created bridged token contract on this side.
      */
-    function _setTokenAddressPair(address _nativeToken, address _bridgedToken) internal {
-        addressStorage[keccak256(abi.encodePacked("homeTokenAddress", _nativeToken))] = _bridgedToken;
-        addressStorage[keccak256(abi.encodePacked("foreignTokenAddress", _bridgedToken))] = _nativeToken;
+    function _setTokenAddressPair(address _nativeToken, address _bridgedToken)
+        internal
+    {
+        addressStorage[
+            keccak256(abi.encodePacked("homeTokenAddress", _nativeToken))
+        ] = _bridgedToken;
+        addressStorage[
+            keccak256(abi.encodePacked("foreignTokenAddress", _bridgedToken))
+        ] = _nativeToken;
 
         emit NewTokenRegistered(_nativeToken, _bridgedToken);
     }

--- a/src/contracts/vendored/mixins/EternalStorage.sol
+++ b/src/contracts/vendored/mixins/EternalStorage.sol
@@ -3,7 +3,6 @@
 // <https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeability/EternalStorage.sol>
 pragma solidity ^0.8.10;
 
-
 /**
  * @title EternalStorage
  * @dev This contract holds all the necessary state variables to carry out the storage of any contract.


### PR DESCRIPTION
This is a helper commit since unfortunately the test plan in `src/contracts/vendored` doesn't work on MacOS.

Eventually, the idea is to rewrite that test plan so that it works on MacOS, but for now I'm formatting the files so that the new vendored imports have the least amount of changes.

This PR will be merged into #62.

### Test Plan

Run test plan:
```
for contract in $(find src/contracts/vendored -name '*.sol' -type f); do
  vendored_url="$(grep --only-matching '<https://.*>' "$contract" | head --lines=1)"
  echo "Diff for $contract, vendored from ${vendored_url:1:-1}"
  diff <(curl --silent "${vendored_url:1:-1}" | npx prettier --parser solidity-parse) "$contract"
done
```

<details><summary>Full output</summary>

```
Diff for src/contracts/vendored/libraries/Strings.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/Strings.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/Strings.sol>
> 
Diff for src/contracts/vendored/libraries/ECDSA.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/cryptography/ECDSA.sol
1a2,7
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/cryptography/ECDSA.sol>
> // The following changes were made:
> // - Vendored imports
> 
6c12
< import "../Strings.sol";
---
> import "./Strings.sol";
Diff for src/contracts/vendored/libraries/Counters.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/Counters.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/Counters.sol>
> 
Diff for src/contracts/vendored/libraries/SafeERC20.sol, vendored from https://raw.githubusercontent.com/gnosis/gp-v2-contracts/7fb88982021e9a274d631ffb598694e6d9b30089/src/contracts/libraries/GPv2SafeERC20.sol
2c2,11
< pragma solidity ^0.7.6;
---
> 
> // Vendored from GPv2 contracts v1.1.2, see:
> // <https://raw.githubusercontent.com/gnosis/gp-v2-contracts/7fb88982021e9a274d631ffb598694e6d9b30089/src/contracts/libraries/GPv2SafeERC20.sol>
> // The following changes were made:
> // - Bumped up Solidity version and checked that the assembly is still valid.
> // - Use own vendored IERC20 instead of custom implementation.
> // - Removed "GPv2" from contract name.
> // - Modified revert messages, including length.
> 
> pragma solidity ^0.8.10;
9c18
< library GPv2SafeERC20 {
---
> library SafeERC20 {
35c44
<         require(getLastTransferResult(token), "GPv2: failed transfer");
---
>         require(getLastTransferResult(token), "SafeERC20: failed transfer");
68c77
<         require(getLastTransferResult(token), "GPv2: failed transferFrom");
---
>         require(getLastTransferResult(token), "SafeERC20: failed transferFrom");
84c93
<         // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
---
>         // <https://docs.soliditylang.org/en/v0.8.10/internals/layout_in_memory.html>
113c122
<                 // <https://docs.soliditylang.org/en/v0.7.6/control-structures.html#external-function-calls>
---
>                 // <https://docs.soliditylang.org/en/v0.8.10/control-structures.html#external-function-calls>
115c124
<                     revertWithMessage(20, "GPv2: not a contract")
---
>                     revertWithMessage(25, "SafeERC20: not a contract")
133c142
<                 revertWithMessage(31, "GPv2: malformed transfer result")
---
>                 revertWithMessage(30, "SafeERC20: bad transfer result")
Diff for src/contracts/vendored/libraries/MerkleProof.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/cryptography/MerkleProof.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/cryptography/MerkleProof.sol>
> 
Diff for src/contracts/vendored/libraries/Math.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/math/Math.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/math/Math.sol>
> 
Diff for src/contracts/vendored/interfaces/draft-IERC20Permit.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/extensions/draft-IERC20Permit.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/extensions/draft-IERC20Permit.sol>
> 
Diff for src/contracts/vendored/interfaces/IERC20Metadata.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/extensions/IERC20Metadata.sol
1a2,7
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/extensions/IERC20Metadata.sol>
> // The following changes were made:
> // - Vendored imports
> 
6c12
< import "../IERC20.sol";
---
> import "./IERC20.sol";
Diff for src/contracts/vendored/interfaces/IERC20.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/IERC20.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/IERC20.sol>
> 
Diff for src/contracts/vendored/interfaces/Context.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/Context.sol
1a2,5
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/Context.sol>
> 
Diff for src/contracts/vendored/mixins/ERC20.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/ERC20.sol
1a2,7
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/ERC20.sol>
> // The following changes were made:
> // - Vendored imports
> 
6,8c12,14
< import "./IERC20.sol";
< import "./extensions/IERC20Metadata.sol";
< import "../../utils/Context.sol";
---
> import "../interfaces/IERC20.sol";
> import "../interfaces/IERC20Metadata.sol";
> import "../interfaces/Context.sol";
Diff for src/contracts/vendored/mixins/EternalStorage.sol, vendored from https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeability/EternalStorage.sol
1c1,4
< pragma solidity 0.7.5;
---
> // SPDX-License-Identifier: LGPL-3.0-or-later
> // Vendored from omnibridge, see:
> // <https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeability/EternalStorage.sol>
> pragma solidity ^0.8.10;
Diff for src/contracts/vendored/mixins/draft-ERC20Permit.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/extensions/draft-ERC20Permit.sol
1a2,7
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/extensions/draft-ERC20Permit.sol>
> // The following changes were made:
> // - Vendored imports
> 
6,10c12,16
< import "./draft-IERC20Permit.sol";
< import "../ERC20.sol";
< import "../../../utils/cryptography/draft-EIP712.sol";
< import "../../../utils/cryptography/ECDSA.sol";
< import "../../../utils/Counters.sol";
---
> import "../interfaces/draft-IERC20Permit.sol";
> import "./ERC20.sol";
> import "./draft-EIP712.sol";
> import "../libraries/ECDSA.sol";
> import "../libraries/Counters.sol";
Diff for src/contracts/vendored/mixins/StorageAccessible.sol, vendored from https://raw.githubusercontent.com/gnosis/gp-v2-contracts/40c349d52d14f8f3c9f787fe2fca5a496bb10ea9/src/contracts/mixins/StorageAccessible.sol
3c3,5
< // Vendored from Gnosis utility contracts with minor modifications:
---
> // Vendored from Gnosis utility contracts, see:
> // <https://raw.githubusercontent.com/gnosis/gp-v2-contracts/40c349d52d14f8f3c9f787fe2fca5a496bb10ea9/src/contracts/mixins/StorageAccessible.sol>
> // The following changes were made:
6,7d7
< // - Added linter directives to ignore low level call and assembly warnings
< // <https://github.com/gnosis/util-contracts/blob/v3.1.0-solc-7/contracts/StorageAccessible.sol>
9c9
< pragma solidity ^0.7.6;
---
> pragma solidity ^0.8.10;
Diff for src/contracts/vendored/mixins/draft-EIP712.sol, vendored from https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/cryptography/draft-EIP712.sol
1a2,7
> 
> // Vendored from OpenZeppelin Contracts v4.4.0, see:
> // <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/utils/cryptography/draft-EIP712.sol>
> // The following changes were made:
> // - Vendored imports
> 
6c12
< import "./ECDSA.sol";
---
> import "../libraries/ECDSA.sol";
Diff for src/contracts/vendored/mixins/BridgedTokensRegistry.sol, vendored from https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeable_contracts/components/bridged/BridgedTokensRegistry.sol
1c1,4
< pragma solidity 0.7.5;
---
> // SPDX-License-Identifier: LGPL-3.0-or-later
> // Vendored from omnibridge, see:
> // <https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeable_contracts/components/bridged/BridgedTokensRegistry.sol>
> pragma solidity ^0.8.10;
3c6
< import "../../../upgradeability/EternalStorage.sol";
---
> import "./EternalStorage.sol";
```
</details>

Output for the new vendored files:
```
Diff for src/contracts/vendored/mixins/EternalStorage.sol, vendored from https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeability/EternalStorage.sol
1c1,4
< pragma solidity 0.7.5;
---
> // SPDX-License-Identifier: LGPL-3.0-or-later
> // Vendored from omnibridge, see:
> // <https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeability/EternalStorage.sol>
> pragma solidity ^0.8.10;
Diff for src/contracts/vendored/mixins/BridgedTokensRegistry.sol, vendored from https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeable_contracts/components/bridged/BridgedTokensRegistry.sol
1c1,4
< pragma solidity 0.7.5;
---
> // SPDX-License-Identifier: LGPL-3.0-or-later
> // Vendored from omnibridge, see:
> // <https://raw.githubusercontent.com/omni/omnibridge/b658c7c217e25c13e61ab9fb1a97010a5656b11e/contracts/upgradeable_contracts/components/bridged/BridgedTokensRegistry.sol>
> pragma solidity ^0.8.10;
3c6
< import "../../../upgradeability/EternalStorage.sol";
---
> import "./EternalStorage.sol";
```