### PR TITLE
Add forwarder contract

### DIFF
--- a/src/contracts/deployment/Forwarder.sol
+++ b/src/contracts/deployment/Forwarder.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+/// @dev This contract exists to act as a guard before a transaction is executed
+/// so that the caller is guaranteed that no code exists at the target address
+/// at the time of the call. This is useful for deterministic deployments: many
+/// deterministic deployer contracts revert if the deterministic contract
+/// address already has some code before the deployment.
+/// However, this might not be a desired behavior in certain scenarios, for
+/// example when deploying deterministically in a DAO proposal, as a revert
+/// would halt the execution of the remaining transactions.
+/// @title Call Forwarder
+/// @author CoW Protocol Developers
+contract Forwarder {
+    /// @dev Forwards a call to a contract if no code is present at the address
+    /// to test. Otherwise, the transaction succeeds without any side effects,
+    /// in particular without forwarding the transaction.
+    /// @param addressToTest Address to test for the presence of bytecode.
+    /// @param data The calldata of the function that will be forwarded.
+    /// @param callTarget The address that will be the target of the call.
+    function forwardIfNoCodeAt(
+        address addressToTest,
+        bytes calldata data,
+        address callTarget
+    ) external {
+        if (addressToTest.code.length == 0) {
+            // solhint-disable-next-line avoid-low-level-calls
+            (bool success, ) = callTarget.call(data);
+            require(success, "Forwarded call failed");
+        }
+    }
+}

--- a/src/contracts/test/EventEmitter.sol
+++ b/src/contracts/test/EventEmitter.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+contract EventEmitter {
+    event Event(address, bytes, uint256);
+
+    function emitEvent(
+        address a,
+        bytes memory b,
+        uint256 c
+    ) external payable {
+        emit Event(a, b, c);
+    }
+}

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -82,7 +82,7 @@ export interface DeployParams {
   [ContractName.RealToken]: RealTokenDeployParams;
   [ContractName.VirtualToken]: VirtualTokenDeployParams;
   [ContractName.BridgedTokenDeployer]: DeploymentHelperDeployParams;
-  [ContractName.Forwarder]: {};
+  [ContractName.Forwarder]: Record<string, never>;
 }
 export type ContructorInput = {
   [ContractName.RealToken]: [string, string, BigNumberish];

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -76,11 +76,13 @@ export enum ContractName {
   RealToken = "CowProtocolToken",
   VirtualToken = "CowProtocolVirtualToken",
   BridgedTokenDeployer = "BridgedTokenDeployer",
+  Forwarder = "Forwarder",
 }
 export interface DeployParams {
   [ContractName.RealToken]: RealTokenDeployParams;
   [ContractName.VirtualToken]: VirtualTokenDeployParams;
   [ContractName.BridgedTokenDeployer]: DeploymentHelperDeployParams;
+  [ContractName.Forwarder]: {};
 }
 export type ContructorInput = {
   [ContractName.RealToken]: [string, string, BigNumberish];
@@ -107,6 +109,7 @@ export type ContructorInput = {
     string,
     BigNumber,
   ];
+  [ContractName.Forwarder]: [];
 };
 
 export function constructorInput<T extends ContractName>(
@@ -179,6 +182,8 @@ export function constructorInput<T extends ContractName>(
       ];
       return result as ContructorInput[T];
     }
+    case ContractName.Forwarder:
+      return [] as ContructorInput[T];
     default: {
       throw new Error(`Invalid contract name: ${contract}`);
     }

--- a/src/ts/forwarder.ts
+++ b/src/ts/forwarder.ts
@@ -1,0 +1,17 @@
+import { Bytes, utils } from "ethers";
+
+export interface Transaction {
+  to: string;
+  data: string;
+}
+
+export interface ForwardIfNoCodeAtInput {
+  addressToTest: string;
+  transaction: Transaction;
+}
+export function getForwardIfNoCodeAtInput({
+  addressToTest,
+  transaction,
+}: ForwardIfNoCodeAtInput): [string, Bytes, string] {
+  return [addressToTest, utils.arrayify(transaction.data), transaction.to];
+}

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,6 +1,7 @@
 export * from "./claim";
 export * from "./csv";
 export * from "./deploy";
+export * from "./forwarder";
 export * from "./permit";
 export * from "./proposal";
 export * from "./split";

--- a/test/Forwarder.test.ts
+++ b/test/Forwarder.test.ts
@@ -1,0 +1,119 @@
+import { Contract, ContractFactory } from "@ethersproject/contracts";
+import { expect } from "chai";
+import { constants, utils } from "ethers";
+import { Interface } from "ethers/lib/utils";
+import { waffle, ethers } from "hardhat";
+
+import {
+  ContractName,
+  getDeterministicDeploymentTransaction,
+  getForwardIfNoCodeAtInput,
+} from "../src/ts";
+
+import { setupDeployer as setupDeterministicDeployer } from "./deterministic-deployment";
+
+const [deployer] = waffle.provider.getWallets();
+
+describe("Forwarder", function () {
+  let forwarder: Contract;
+  let eventEmitter: Contract;
+  let EventEmitterFactory: ContractFactory;
+
+  beforeEach(async function () {
+    // Note: using an actual contract instead of a mock because it is not
+    // possible to easily test that a function was indeed call in the mock.
+    // This is not supported by Hardhat:
+    // https://ethereum-waffle.readthedocs.io/en/latest/matchers.html#called-on-contract
+    EventEmitterFactory = (
+      await ethers.getContractFactory("EventEmitter")
+    ).connect(deployer);
+    eventEmitter = await EventEmitterFactory.deploy();
+
+    const ForwardFactory = (
+      await ethers.getContractFactory("Forwarder")
+    ).connect(deployer);
+    forwarder = await ForwardFactory.deploy();
+  });
+
+  it("forwards call if there is no code at target", async function () {
+    const callArgs = ["0x" + "42".repeat(20), "0xca11da7a", 42];
+    expect(await ethers.provider.getCode(constants.AddressZero)).to.equal("0x");
+
+    const tx = {
+      data: EventEmitterFactory.interface.encodeFunctionData(
+        "emitEvent",
+        callArgs,
+      ),
+      to: eventEmitter.address,
+    };
+    await expect(
+      forwarder.forwardIfNoCodeAt(
+        ...getForwardIfNoCodeAtInput({
+          addressToTest: constants.AddressZero,
+          transaction: tx,
+        }),
+      ),
+    )
+      .to.emit(eventEmitter, "Event")
+      .withArgs(...callArgs);
+  });
+
+  it("does not forward call if target has code", async function () {
+    const contract = await waffle.deployMockContract(deployer, []);
+    expect(await ethers.provider.getCode(contract.address)).not.to.equal("0x");
+
+    const tx = {
+      data: "0x",
+      to: eventEmitter.address,
+    };
+
+    await expect(
+      forwarder.forwardIfNoCodeAt(
+        ...getForwardIfNoCodeAtInput({
+          addressToTest: contract.address,
+          transaction: tx,
+        }),
+      ),
+    ).not.to.emit(eventEmitter, "Event");
+  });
+
+  it("reverts if forwarded call reverts", async function () {
+    const abi = ["function revert()"];
+    const reverterInterface = new Interface(abi);
+    const reverter = await waffle.deployMockContract(deployer, abi);
+
+    expect(await ethers.provider.getCode(constants.AddressZero)).to.equal("0x");
+    await reverter.mock.revert.reverts();
+    const tx = {
+      data: reverterInterface.encodeFunctionData("revert"),
+      to: eventEmitter.address,
+    };
+
+    await expect(
+      forwarder.forwardIfNoCodeAt(
+        ...getForwardIfNoCodeAtInput({
+          addressToTest: constants.AddressZero,
+          transaction: tx,
+        }),
+      ),
+    ).to.be.revertedWith("Forwarded call failed");
+  });
+
+  it("computes deterministic deployment address", async function () {
+    const salt = utils.id("deployment in test");
+    await setupDeterministicDeployer(deployer);
+    const { safeTransaction, address } =
+      await getDeterministicDeploymentTransaction(
+        ContractName.Forwarder,
+        {},
+        ethers,
+        salt,
+      );
+    expect(await ethers.provider.getCode(address)).to.equal("0x");
+    await deployer.sendTransaction({
+      to: safeTransaction.to,
+      data: safeTransaction.data,
+    });
+    expect(await ethers.provider.getCode(address)).not.to.equal("0x");
+  });
+});


### PR DESCRIPTION
Both the Gnosis Safe Proxy Factory and the deterministic deployer used in this repo revert if they deploy a contract at an address that already has a contract. This could happen if for example someone deployed the same contract at that address in a previous transaction.
Since our DAO proposal depends on deploying many contracts deterministically and permissionlessly, this could be an issue as somebody else could deploy one of the deterministic contract as soon as the DAO proposal is public and make any subsequent transaction unexecutable.

This PR is the first step in resolving this issue. It acts as a barrier before a transaction is executed. If at the target address there already is code, then the transaction succeeds without any further effects. Otherwise, it executes the original transaction (in our current issue, it will be a deterministic deployment).

This PR only introduces the new contract.

In terms of costs, this extra call adds about 10k extra gas. Surprisingly, I didn't notice any difference between using `addressToTest.code` compared to `addressToTest.codehash`, which makes me think that the optimizer already takes care of using the best opcode for this comparison.

### Test Plan

New unit tests.
