### PR TITLE
Add script to deploy and verify forwarder

### DIFF
--- a/src/tasks/deploy-forwarder.ts
+++ b/src/tasks/deploy-forwarder.ts
@@ -1,0 +1,66 @@
+import type { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
+import { constants } from "ethers";
+import { task, types } from "hardhat/config";
+import type { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import {
+  ContractName,
+  DEPLOYER_CONTRACT,
+  getDeterministicDeploymentTransaction,
+} from "../ts";
+
+interface Args {
+  salt: string;
+}
+
+const setupDeployForwarder: () => void = () => {
+  task(
+    "deploy-forwarder",
+    "Deploys the transaction forwarder on the chosen network.",
+  )
+    .addOptionalParam(
+      "salt",
+      "The salt to use for the deterministic deployment.",
+      constants.HashZero,
+      types.string,
+    )
+    .setAction(deployForwarder);
+};
+export { setupDeployForwarder };
+
+async function deployForwarder(
+  { salt }: Args,
+  hre: HardhatRuntimeEnvironment & { ethers: HardhatEthersHelpers },
+) {
+  const { ethers } = hre;
+  const [deployer] = await ethers.getSigners();
+  console.log(`Using deployer ${deployer.address}`);
+
+  if ((await ethers.provider.getCode(DEPLOYER_CONTRACT)) === "0x") {
+    // Note: it is already deployed on mainnet, Rinkeby and Gnosis Chain.
+    throw new Error(
+      `Deterministic deployer not available on network ${hre.network.name}. Please deploy it first.`,
+    );
+  }
+
+  const { safeTransaction, address } =
+    await getDeterministicDeploymentTransaction(
+      ContractName.Forwarder,
+      {},
+      ethers,
+      salt,
+    );
+
+  if ((await ethers.provider.getCode(address)) !== "0x") {
+    throw new Error(`Contract already deployed at address ${address}`);
+  }
+
+  console.log(`Contract will be deployed at address ${address}`);
+  const request = await deployer.sendTransaction({
+    to: safeTransaction.to,
+    data: safeTransaction.data,
+  });
+  console.log(`Sent deployment transaction, txhash ${request.hash}`);
+  await request.wait();
+  console.log("Deployment transaction successfully included in a block.");
+}

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,9 +1,11 @@
+import { setupDeployForwarder } from "./deploy-forwarder";
 import { setupDeployment } from "./deployment";
 import { setupTestClaimsTask } from "./test-claims";
 import { setupTestDeploymentTask } from "./test-deployment";
 import { setupVerifyContractCodeTask } from "./verify-contract-code";
 
 export function setupTasks(): void {
+  setupDeployForwarder();
   setupDeployment();
   setupTestClaimsTask();
   setupTestDeploymentTask();

--- a/src/tasks/verify-contract-code.ts
+++ b/src/tasks/verify-contract-code.ts
@@ -20,8 +20,14 @@ const setupVerifyContractCodeTask: () => void = () => {
     "verify-contract-code",
     "Verify the contract code on the network's block exporer.",
   )
-    .addOptionalParam("virtualToken", "The address of the virtual vCOW token.")
-    .addOptionalParam("forwarder", "The address of the virtual vCOW token.")
+    .addOptionalParam(
+      "virtualToken",
+      "The address of the deployed virtual vCOW token.",
+    )
+    .addOptionalParam(
+      "forwarder",
+      "The address of the deployed forwarder contract.",
+    )
     .setAction(verifyContractCode);
 };
 export { setupVerifyContractCodeTask };

--- a/src/tasks/verify-contract-code.ts
+++ b/src/tasks/verify-contract-code.ts
@@ -86,7 +86,7 @@ async function verifyContract(
   hre: HardhatRuntimeEnvironment & { ethers: HardhatEthersHelpers },
 ) {
   console.log(`Verifying contract ${name} at address ${address}`);
-  const contract = (await hre.ethers.getContractFactory(ContractName.RealToken))
+  const contract = (await hre.ethers.getContractFactory(name))
     .attach(address)
     .connect(hre.ethers.provider);
 

--- a/src/tasks/verify-contract-code.ts
+++ b/src/tasks/verify-contract-code.ts
@@ -11,8 +11,8 @@ import {
 } from "../ts";
 
 interface Args {
-  virtualTokenAddress?: string;
-  forwarderAddress?: string;
+  virtualToken?: string;
+  forwarder?: string;
 }
 
 const setupVerifyContractCodeTask: () => void = () => {
@@ -20,32 +20,26 @@ const setupVerifyContractCodeTask: () => void = () => {
     "verify-contract-code",
     "Verify the contract code on the network's block exporer.",
   )
-    .addOptionalParam(
-      "virtualTokenAddress",
-      "The address of the virtual vCOW token.",
-    )
-    .addOptionalParam(
-      "forwarderAddress",
-      "The address of the virtual vCOW token.",
-    )
+    .addOptionalParam("virtualToken", "The address of the virtual vCOW token.")
+    .addOptionalParam("forwarder", "The address of the virtual vCOW token.")
     .setAction(verifyContractCode);
 };
 export { setupVerifyContractCodeTask };
 
 async function verifyContractCode(
-  { virtualTokenAddress, forwarderAddress }: Args,
+  { virtualToken, forwarder }: Args,
   hre: HardhatRuntimeEnvironment,
 ) {
   if (hre.network.name === "xdai") {
     throw new Error("Blockscout is currently not supported");
   }
 
-  if (virtualTokenAddress !== undefined) {
-    await verifyVirtualToken(virtualTokenAddress, hre);
+  if (virtualToken !== undefined) {
+    await verifyVirtualToken(virtualToken, hre);
   }
 
-  if (forwarderAddress !== undefined) {
-    await verifyContract(ContractName.Forwarder, forwarderAddress, hre);
+  if (forwarder !== undefined) {
+    await verifyContract(ContractName.Forwarder, forwarder, hre);
   }
 }
 


### PR DESCRIPTION
A script that makes the newly introduced forwarder available for use on any network.

### Test Plan

```
$ npx hardhat deploy-forwarder --network rinkeby --salt 0xd78f4e543aa973b54b3e76a2042862730b862a49048ca0736527a8632a2969d9
Using deployer 0xdd2f141816B42f36897a76dFd16b2929cdC752f1
Contract will be deployed at address 0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781.
Sent deployment transaction, txhash 0x5906a51923c0a345dc832b16fae759a7df88effef6f5e4399ca071a9cecca6a1...
Deployment transaction successfully included in a block.

$ yarn verify --network rinkeby --forwarder 0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781
yarn run v1.22.10
$ hardhat verify-contract-code --network rinkeby --forwarder-address 0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781
Verifying contract Forwarder at address 0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781
Compiling 53 files with 0.8.10
Solidity compilation finished successfully
Compiling 1 file with 0.8.10
Successfully submitted source code for contract
src/contracts/deployment/Forwarder.sol:Forwarder at 0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781
for verification on the block explorer. Waiting for verification result...

Successfully verified contract Forwarder on Etherscan.
https://rinkeby.etherscan.io/address/0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781#code
Done in 28.14s.
```

Then, see [verified contract on Etherscan](https://rinkeby.etherscan.io/address/0x30e11c57EcF2Aa5fe5A6C76f0b564cc77a3Db781#code).