### PR TITLE
Use different amounts for different claims of the same user

### DIFF
--- a/src/tasks/test-claims.ts
+++ b/src/tasks/test-claims.ts
@@ -104,17 +104,17 @@ export function generateClaims(users: string[]): Claim[] {
     )
     .filter((configuration) => configuration.size !== 0);
 
-  const pseudorandomAmount = (i: number) =>
-    BigNumber.from(id(i.toString()))
+  const pseudorandomAmount = (userIndex: number, claimIndex: number) =>
+    BigNumber.from(id(`${userIndex}/${claimIndex}`))
       .mod(10000)
       .mul(utils.parseUnits("1", metadata.real.decimals));
   return users
     .map((account, i) =>
       Array.from(
         admissibleClaimConfigurations[i % admissibleClaimConfigurations.length],
-      ).map((type) => ({
+      ).map((type, j) => ({
         account,
-        claimableAmount: pseudorandomAmount(i),
+        claimableAmount: pseudorandomAmount(i, j),
         type,
       })),
     )


### PR DESCRIPTION
A simple change that makes the amounts of the generated test claims likely to be different for the same user. Currently, even is the same user has different claims, the amounts are the same.

### Test Plan

```
$ npx hardhat test-claims --user-count 10 --mnemonic "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
```

Its output is now:
```
Account,Airdrop,GnoOption,UserOption,Investor,Team,Advisor
0x627306090abaB3A6e1400e9345bC60c78a8BEf57,1557000000000000000000,,,,,
0x6503D95e3F20389EE9496b277ABfFDb8eCCD2cc5,,6084000000000000000000,,,,
0xe942Ea5869f348e036Ad8b9098659D06c574Aa38,6502000000000000000000,134000000000000000000,,,,
0x47868d0F638F7A4b0Ad06598E0AbC72C22983388,,,6714000000000000000000,,,
0x4829346af86f4C4E97e3F232688B73890fb8dFaa,290000000000000000000,,207000000000000000000,,,
0x02E510B1Ca7C59Bd16c6de86AEEf4871AB5D49ba,,3979000000000000000000,7957000000000000000000,,,
0x4D1339B9a6F87a8A9c154f9CF407BB65dA19d875,3257000000000000000000,926000000000000000000,6029000000000000000000,,,
0x19514D85A40659C63514fBa49b199DA6e8832B73,,,,786000000000000000000,,
0xd0E74feCA59ED3840165AbCE1D2B4Bb3bD8ED570,4722000000000000000000,,,7441000000000000000000,,
0x51F56aA4F6111E9073D4388703b46B84ece89FF8,,3159000000000000000000,,89000000000000000000,,
```
