### PR TITLE
Fix xDai token price

### DIFF
--- a/src/tasks/deployment-of-bridged-token-deployer.ts
+++ b/src/tasks/deployment-of-bridged-token-deployer.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 
-import { constants } from "ethers";
+import { constants, utils } from "ethers";
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -13,10 +13,7 @@ import {
   ContractName,
 } from "../ts";
 import { Args, Settings } from "../ts/lib/common-interfaces";
-import {
-  defaultTokens,
-  nativeTokenPriceGnosisChain,
-} from "../ts/lib/constants";
+import { defaultTokens } from "../ts/lib/constants";
 import { dummyVirtualTokenCreationSettings } from "../ts/lib/dummy-instantiation";
 import { removeSplitClaimFiles, splitClaimsAndSaveToFolder } from "../ts/split";
 
@@ -118,7 +115,7 @@ async function generateDeployment(
     communityFundsTarget: cowDao,
     gnoToken: defaultTokens.gno[chainId],
     gnoPrice: settings.virtualCowToken.gnoPrice,
-    nativeTokenPrice: nativeTokenPriceGnosisChain,
+    nativeTokenPrice: utils.parseUnits("0.15", 18), // the price of one unit of COW in xDAI
     wrappedNativeToken: defaultTokens.weth[chainId],
   };
 

--- a/src/ts/lib/constants.ts
+++ b/src/ts/lib/constants.ts
@@ -19,8 +19,5 @@ export const defaultTokens = {
   },
 } as const;
 
-// The price of the native token in Gnosis Chain is the price of XDAI = 10**18
-export const nativeTokenPriceGnosisChain = utils.parseEther("1");
-
 // the amount of tokens to relay to the omni bridge at deployment time
 export const amountToRelay = utils.parseEther("1");


### PR DESCRIPTION
Fixes a serious issue in the choice of parameters for the deployer on Gnosis Chain. The factory was hardcoded to use 1$ as a price for xDai, however that name refers to the price of 1 COW in xDai, which is 0.15$.

### Test Plan

Untested, as this action is part of a script and not a standalone function.