### PR TITLE
blockscout contract verification

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -123,6 +123,9 @@ export default {
     gasPrice: 21,
   },
   etherscan: {
-    apiKey: ETHERSCAN_API_KEY,
+    apiKey: {
+      xdai: "any api key is good currently",
+      mainnet: ETHERSCAN_API_KEY,
+    },
   },
 };

--- a/src/tasks/verify-contract-code.ts
+++ b/src/tasks/verify-contract-code.ts
@@ -8,7 +8,7 @@ import {
   DeployParams,
   getDeployArgsFromRealToken,
   getDeployArgsFromVirtualToken,
-  getDeployArgsFromBridgeTokenDeployer,
+  getDeployArgsFromBridgedTokenDeployer,
 } from "../ts";
 
 interface Args {
@@ -114,7 +114,7 @@ async function verifyContract(
       break;
     }
     case ContractName.BridgedTokenDeployer: {
-      deployArgs = await getDeployArgsFromBridgeTokenDeployer(contract);
+      deployArgs = await getDeployArgsFromBridgedTokenDeployer(contract);
       break;
     }
     default: {

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -395,7 +395,7 @@ export async function getDeployArgsFromVirtualToken(
   );
 }
 
-export async function getDeployArgsFromBridgeTokenDeployer(
+export async function getDeployArgsFromBridgedTokenDeployer(
   bridgedTokenDeployer: Contract,
 ): Promise<DeploymentHelperDeployParams> {
   const promisedParameters: Record<

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -394,3 +394,28 @@ export async function getDeployArgsFromVirtualToken(
     ),
   );
 }
+
+export async function getDeployArgsFromBridgeTokenDeployer(
+  bridgedTokenDeployer: Contract,
+): Promise<DeploymentHelperDeployParams> {
+  const promisedParameters: Record<
+    keyof DeploymentHelperDeployParams,
+    Promise<DeploymentHelperDeployParams[keyof DeploymentHelperDeployParams]>
+  > = {
+    merkleRoot: bridgedTokenDeployer.merkleRoot(),
+    foreignToken: bridgedTokenDeployer.foreignToken(),
+    multiTokenMediatorGnosisChain: bridgedTokenDeployer.multiTokenMediator(),
+    communityFundsTarget: bridgedTokenDeployer.communityFundsTarget(),
+    gnoToken: bridgedTokenDeployer.gnoToken(),
+    gnoPrice: bridgedTokenDeployer.gnoPrice(),
+    wrappedNativeToken: bridgedTokenDeployer.wrappedNativeToken(),
+    nativeTokenPrice: bridgedTokenDeployer.nativeTokenPrice(),
+  };
+  return Object.fromEntries(
+    await Promise.all(
+      Object.entries(promisedParameters).map(async ([key, entry]) =>
+        entry.then((e) => [key, e]),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Enables blockscout verification. In the end it was super easy, as they also enabled hardhat verifications

### Test Plan

Deploy contract of your choice.(always think about modifing the name and symbol to TEST
Then run the script, e.g.
```
npx hardhat verify-contract-code --bridged-token-deployer  "0xee59869f84FBa732A4EA4Ad9c7B6D026BDF2140F" --network gnosischain 
```
Here are two verified addresses:
[Forwarder](https://blockscout.com/xdai/mainnet/address/0x1167594438f3314fAB7cbE96F2Bc00db6c9ac8a3/contracts)
[BridgedTokenDeployer](https://blockscout.com/xdai/mainnet/address/0xee59869f84FBa732A4EA4Ad9c7B6D026BDF2140F/read-contract)