### PR TITLE
Add Rinkeby contract verification key

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -126,6 +126,7 @@ export default {
     apiKey: {
       xdai: "any api key is good currently",
       mainnet: ETHERSCAN_API_KEY,
+      rinkeby: ETHERSCAN_API_KEY,
     },
   },
 };


### PR DESCRIPTION
I've noticed that contract verification is not working anymore on Rinkeby, the easy fix for that is in this PR.

### Test plan

Deploy and verify a contract on Rinkeby, e.g. (note: change the salt and address to try):
```
npx hardhat deploy-forwarder --network rinkeby --salt 0xd78f4e543aa973b54b3e76a2042862730b862a49048ca0736527a8632a2969ee
yarn verify --network rinkeby --forwarder 0xcC0A4a675D7319e18647A8Edc05BC7569a00723a
```
[Result](https://rinkeby.etherscan.io/address/0xcC0A4a675D7319e18647A8Edc05BC7569a00723a#code).