### PR TITLE
Script to only generate MerkleRoot from claim file

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Run the verifier to check that your deployment was successful:
 ```
 npx hardhat verify-contract-code --bridged-token-deployer  "<address from addresses.json>" --network gnosischain  
 ```
-and copy <address from addresses.json> into the settings.json for the entry `bridgedTokenDeployer` for the next step.
+and copy \<address from addresses.json\> into the settings.json for the entry `bridgedTokenDeployer` for the next step.
 
 
 #### 2nd step: Mainnet proposal creation
@@ -162,3 +162,11 @@ yarn verify $VIRTUAL_TOKEN_ADDRESS --network $NETWORK
 ```
 
 It is currently only possible to verify the contract code on mainnet or Rinkeby.
+
+### Computing the Merkle Root
+
+To just compute the merkle root of a given claim file, use the following script
+
+```
+yarn hardhat compute-merkle-root --claims <path to csv>
+```

--- a/src/tasks/compute-merkle-root.ts
+++ b/src/tasks/compute-merkle-root.ts
@@ -1,0 +1,24 @@
+import { task } from "hardhat/config";
+
+import { computeProofs, parseCsvFile } from "../ts";
+import { Args } from "../ts/lib/common-interfaces";
+
+const setupComputeMerkleRootTask: () => void = () => {
+  task(
+    "compute-merkle-root",
+    "Computes the merkle root for a list of claims from a csv",
+  )
+    .addParam(
+      "claims",
+      "Path to the CSV file that contains the list of claims.",
+    )
+    .setAction(computeMerkleRoot);
+};
+
+async function computeMerkleRoot({ claims: claimCsv }: Args): Promise<void> {
+  const claims = await parseCsvFile(claimCsv);
+  const { merkleRoot } = computeProofs(claims);
+  console.log(merkleRoot);
+}
+
+export { setupComputeMerkleRootTask };

--- a/src/tasks/compute-merkle-root.ts
+++ b/src/tasks/compute-merkle-root.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 
 import { computeProofs, parseCsvFile } from "../ts";
-import { Args } from "../ts/lib/common-interfaces";
 
 const setupComputeMerkleRootTask: () => void = () => {
   task(
@@ -15,9 +14,13 @@ const setupComputeMerkleRootTask: () => void = () => {
     .setAction(computeMerkleRoot);
 };
 
-async function computeMerkleRoot({ claims: claimCsv }: Args): Promise<void> {
-  const claims = await parseCsvFile(claimCsv);
-  const { merkleRoot } = computeProofs(claims);
+interface Args {
+  claims: string;
+}
+
+async function computeMerkleRoot({ claims }: Args): Promise<void> {
+  const parsedClaims = await parseCsvFile(claims);
+  const { merkleRoot } = computeProofs(parsedClaims);
   console.log(merkleRoot);
 }
 

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,3 +1,4 @@
+import { setupComputeMerkleRootTask } from "./compute-merkle-root";
 import { setupDeployForwarder } from "./deploy-forwarder";
 import { setupDeployment } from "./deployment";
 import { setupBridgedTokenDeployerTask } from "./deployment-of-bridged-token-deployer";
@@ -14,4 +15,5 @@ export function setupTasks(): void {
   setupTestExecuteProposalTask();
   setupVerifyContractCodeTask();
   setupBridgedTokenDeployerTask();
+  setupComputeMerkleRootTask();
 }


### PR DESCRIPTION
Given we are comparing a lot of different allocation files with one another, I thought it might be helpful to create a simple script that maps an allocation file to the merkle root (so that it's easily sharable via slack).

All the functionality was already there from creating the deployment transactions, so this PR just creates a smaller wrapper task around it.

### Test Plan

Run the new command with a mainnet and gchain allocation.
