### PR TITLE
Add mainnet GIP-13 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ The output files are in the `output/deployment` folder, which include:
 3. `claims.json`, a list of all the claims of all user. It contains all information needed by a user to perform a claim onchain. 
 4. `chunks` and `mapping.json`, which contain a reorganized version of the same claims that are available in `claims.json`. This format is easier to handle by a web frontend. The format is very similar to the one used in the Uniswap airdrop.
 
+#### Verify GIP-13 proposal
+
+##### Mainnet
+
+The scripts in this repo have been used to generate the [snapshot proposal](https://snapshot.org/#/gnosis.eth/proposal/0x9b12a093e17e92b56d070ed876883d8c2331678ca3945e44f66dd416cfd47a64) for the [Gnosis Improvement Proposal #13](https://forum.gnosis.io/t/gip-13-gnosis-protocol-token/1529).
+
+You can verifying the correctness of the transactions by running:
+
+```
+source example/mainnet/.env # fill the env file with the required parameters
+wget https://raw.githubusercontent.com/gnosis/cow-token-allocation/2111ee1e678be345ba8b33e80be5fa0d0ed780f4/allocations-mainnet.csv
+npx hardhat deployment --network mainnet --claims ./allocations-mainnet.csv --settings ./example/Gnosis-DAO-proposal-settings.json
+```
+
+The output file `./output/deployment/steps.json` contains all the transactions that are included in the snapshot.
+
 #### Test deployment
 
 A script that can be used to create a live test deployment of the token contract on the supported networks.

--- a/example/Gnosis-DAO-proposal-settings.json
+++ b/example/Gnosis-DAO-proposal-settings.json
@@ -1,0 +1,39 @@
+{
+  "gnosisDao": "0x0DA0C3e52C977Ed3cBc641fF02DD271c3ED55aFe",
+  "cowDao": {
+    "expectedAddress": "0xcA771eda0c70aA7d053aB1B25004559B918FE662",
+    "threshold": 3,
+    "owners": [
+      "0x04ce1ccF81AE660e23ca0c0823911df709B0E7Fc",
+      "0x0a2aaA50135dA1628c8D29216f25Bf2a28efb219",
+      "0x54b8B7DDF8453De6D53a59E91877a5aD1A01B5b8",
+      "0x5Efd3E2E18696A44A4cB3F3eA5F637C3F3CcCf0f",
+      "0xf10Fe968d1856131FC6835ed7d7126eaF8b5a6b6"
+    ],
+    "nonce": "107036350621206504379033131555853508365355772386871693175289686856522696020774"
+  },
+  "teamController": {
+    "expectedAddress": "0xca07EaA4253638D286caD71CBcEec11803F2709A",
+    "threshold": 2,
+    "owners": [
+      "0x2CaEf7f0EE82fb0ABf1AB0dCD3A093803002e705",
+      "0x762a821270E6a1AfA44327BdA381a91542c53317",
+      "0xd364d2902B46186516Cba58C3d4B93e437eEa1fb"
+    ],
+    "nonce": "49248429577818386963806474957318904108134388502570293758782116574269977524379"
+  },
+  "cowToken": {
+    "expectedAddress": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+    "salt": "0x6499070f9cf29151686014acc51a62557d819ba5b85a4db6079da7036a16865f"
+  },
+  "virtualCowToken": {
+    "gnoPrice": "585937500000000",
+    "nativeTokenPrice": "62833014979390"
+  },
+  "bridge": {
+    "multiTokenMediatorGnosisChain": "0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d",
+    "multiTokenMediatorETH": "0x88ad09518695c6c3712AC10a214bE5109a655671",
+    "arbitraryMessageBridgeETH": "0x4C36d2919e407f0Cc2Ee3c993ccF8ac26d9CE64e"
+  },
+  "bridgedTokenDeployer": "0x66a120c804edf523eb8081849b1b9f2ca80c3e14"
+}


### PR DESCRIPTION
Adds a small description on what to do to verify the GIP-13 snapshot proposal transaction on mainnet. This also includes the settings used to generate all the steps.

### Test Plan

Follow instructions in the readme.
