### PR TITLE
Clean up Hardhat configs

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -36,15 +36,6 @@ const {
 const DEFAULT_MNEMONIC =
   "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
 
-const sharedNetworkConfig: HttpNetworkUserConfig = {};
-if (PK) {
-  sharedNetworkConfig.accounts = [PK];
-} else {
-  sharedNetworkConfig.accounts = {
-    mnemonic: MNEMONIC || DEFAULT_MNEMONIC,
-  };
-}
-
 if (
   ["rinkeby", "mainnet"].includes(argv.network) &&
   NODE_URL === undefined &&
@@ -55,8 +46,21 @@ if (
   );
 }
 
-if (NODE_URL !== undefined) {
+const sharedNetworkConfig: HttpNetworkUserConfig = {};
+if (NODE_URL) {
   sharedNetworkConfig.url = NODE_URL;
+}
+if (PK) {
+  sharedNetworkConfig.accounts = [PK];
+} else {
+  sharedNetworkConfig.accounts = {
+    mnemonic: MNEMONIC || DEFAULT_MNEMONIC,
+  };
+}
+if (GAS_PRICE_GWEI) {
+  sharedNetworkConfig.gasPrice = utils
+    .parseUnits(GAS_PRICE_GWEI, "gwei")
+    .toNumber();
 }
 
 const { mocha, initialBaseFeePerGas, optimizerDetails } =
@@ -69,7 +73,6 @@ export default {
   paths: {
     artifacts: "build/artifacts",
     cache: "build/cache",
-    deploy: "src/deploy",
     sources: "src/contracts",
   },
   solidity: {
@@ -104,11 +107,6 @@ export default {
     gnosischain: {
       ...sharedNetworkConfig,
       url: "https://rpc.gnosischain.com",
-      gasPrice: GAS_PRICE_GWEI
-        ? parseInt(
-            utils.parseUnits(GAS_PRICE_GWEI.toString(), "gwei").toString(),
-          )
-        : "auto",
       chainId: 100,
     },
   },
@@ -120,7 +118,7 @@ export default {
   gasReporter: {
     enabled: REPORT_GAS ? true : false,
     currency: "USD",
-    gasPrice: 21,
+    gasPrice: 100,
   },
   etherscan: {
     apiKey: {


### PR DESCRIPTION
Small changes to the Hardhat configs file to make it more organized, update some parameters, and remove some unused lines.

### Test Plan

The only nontrivial change should be changing how `GAS_PRICE_GWEI` is parsed. To see that it's the same, you can test on both main and this branch that the configs are the same:
```
$ npx hardhat console --network gnosischain
> hre.network.config.gasPrice
220000000000
```