### PR TITLE
Ignore @openzeppelin/contracts version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: monday
       time: "02:00"
     open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: "@openzeppelin/contracts"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@gnosis.pm/safe-contracts": "^1.3.0",
-    "@openzeppelin/contracts": "^4.4.2",
+    "@openzeppelin/contracts": "=4.4.2",
     "ethereumjs-util": "^7.1.4",
     "ethers": "^5.5.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -640,7 +640,7 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.4.2":
+"@openzeppelin/contracts@=4.4.2":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
   integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==


### PR DESCRIPTION
Closes #112.

Dependabot wants to update `@openzeppelin/contracts` in #112. However, there are some contract updates to some of the contract that we vendor in this repo (see changelog in #112). To guarantee that the vendored contracts will stay compatible with the imported code and interfaces in the future, we freeze the current version of `@openzeppelin/contracts`.

### Test Plan

Untested. Code copied from [here](https://github.com/gnosis/gp-v2-contracts/blob/main/.github/dependabot.yml).