### PR TITLE
Compute tx hashes in proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ wget https://raw.githubusercontent.com/gnosis/cow-token-allocation/2111ee1e678be
 npx hardhat deployment --network mainnet --claims ./allocations-mainnet.csv --settings ./example/Gnosis-DAO-proposal-settings.json
 ```
 
-The output file `./output/deployment/steps.json` contains all the transactions that are included in the snapshot.
+The output file `./output/deployment/txhashes.json` contains the hashes of all transactions that are included in the snapshot and can be compared to the batch transaction hashes that are shown in the Snapshot interface.
 
 ##### Gnosis Chain
 

--- a/example/Gnosis-DAO-proposal-settings.json
+++ b/example/Gnosis-DAO-proposal-settings.json
@@ -35,5 +35,6 @@
     "multiTokenMediatorETH": "0x88ad09518695c6c3712AC10a214bE5109a655671",
     "arbitraryMessageBridgeETH": "0x4C36d2919e407f0Cc2Ee3c993ccF8ac26d9CE64e"
   },
-  "bridgedTokenDeployer": "0x66a120c804edf523eb8081849b1b9f2ca80c3e14"
+  "bridgedTokenDeployer": "0x66a120c804edf523eb8081849b1b9f2ca80c3e14",
+  "multisend": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
 }

--- a/src/tasks/test-execute-proposal.ts
+++ b/src/tasks/test-execute-proposal.ts
@@ -3,7 +3,7 @@ import { BigNumber, Contract } from "ethers";
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { groupWithMultisendCallOnly } from "../ts";
+import { groupMultipleTransactions } from "../ts";
 import { Args as ArgsDeployment } from "../ts/lib/common-interfaces";
 
 import { generateDeployment } from "./ts/proposal";
@@ -81,9 +81,10 @@ async function executeProposal(
     throw new Error(`Chain id ${chainId} not supported by the Gnosis Safe`);
   }
 
-  for (const tx of groupWithMultisendCallOnly(
+  for (const tx of groupMultipleTransactions(
     steps,
-    defaultSafeDeploymentAddresses(chainId).multisendCallOnly,
+    settings.multisend ??
+      defaultSafeDeploymentAddresses(chainId).multisendCallOnly,
   )) {
     let response: TransactionResponse;
     if (gnosisDao === null) {

--- a/src/tasks/ts/snapshot.ts
+++ b/src/tasks/ts/snapshot.ts
@@ -1,0 +1,30 @@
+import { Contract } from "@ethersproject/contracts";
+import { MetaTransaction } from "@gnosis.pm/safe-contracts";
+import { providers } from "ethers";
+
+// Shortened ABI for the smart contract that executes Snapshot transactions. See:
+// https://github.com/gnosis/zodiac-module-reality/blob/64530f2b6577f756328e0c898d33534e0bcc6c06/contracts/RealityModule.sol
+const realityModuleAbi = [
+  "function getTransactionHash(address,uint256,bytes memory,uint8,uint256) public view returns (bytes32)",
+];
+
+export class RealityModule {
+  instance: Contract;
+
+  constructor(address: string, provider: providers.Provider) {
+    this.instance = new Contract(address, realityModuleAbi, provider);
+  }
+
+  async getTransactionHash(
+    tx: MetaTransaction,
+    index: number,
+  ): Promise<string> {
+    return this.instance.getTransactionHash(
+      tx.to,
+      tx.value,
+      tx.data,
+      tx.operation,
+      index,
+    );
+  }
+}

--- a/src/ts/lib/common-interfaces.ts
+++ b/src/ts/lib/common-interfaces.ts
@@ -19,4 +19,5 @@ export interface BridgeParameter {
 export interface Settings
   extends Omit<DeploymentProposalSettings, "virtualCowToken"> {
   virtualCowToken: VirtualTokenSettings;
+  multisend?: string;
 }

--- a/src/ts/lib/constants.ts
+++ b/src/ts/lib/constants.ts
@@ -19,5 +19,11 @@ export const defaultTokens = {
   },
 } as const;
 
+export const realityModule = {
+  // Note that this was added in the snapshot transaction that enabled the Reality module for the Gnosis DAO.
+  // https://snapshot.org/#/gnosis.eth/proposal/QmNMRBnipvRfos9ze1MrKpFAsHqxhNrmxjrXzxJnhFif9b
+  "1": "0x0ebac21f7f6a6599b5fa5f57baaa974adfec4613",
+} as const;
+
 // the amount of tokens to relay to the omni bridge at deployment time
 export const amountToRelay = utils.parseEther("1");

--- a/src/ts/proposal.ts
+++ b/src/ts/proposal.ts
@@ -486,18 +486,16 @@ export function deploymentStepsIntoArray(
   ];
 }
 
-export function groupWithMultisendCallOnly(
+export function groupMultipleTransactions(
   proposalSteps: MetaTransaction[][],
-  multisendCallOnlyAddress: string,
+  multisendAddress: string,
 ): MetaTransaction[] {
   return proposalSteps.map((transactions) => {
-    if (
-      transactions.some((tx) => tx.operation === SafeOperation.DelegateCall)
-    ) {
-      throw new Error(
-        "Cannot join with MultisendCallOnly because one of the joined transactions is a delegatecall",
-      );
+    if (transactions.length === 0) {
+      throw new Error("Group contains zero transactions");
     }
-    return multisend(transactions, multisendCallOnlyAddress);
+    return transactions.length === 1
+      ? transactions[0]
+      : multisend(transactions, multisendAddress);
   });
 }

--- a/test/mainnet/addresses.test.ts
+++ b/test/mainnet/addresses.test.ts
@@ -4,7 +4,7 @@ import { Contract, utils } from "ethers";
 import hre, { ethers } from "hardhat";
 
 import { DEPLOYER_CONTRACT } from "../../src/ts";
-import { defaultTokens } from "../../src/ts/lib/constants";
+import { realityModule, defaultTokens } from "../../src/ts/lib/constants";
 
 import { forkMainnet, stopMainnetFork } from "./chain-fork";
 
@@ -20,7 +20,7 @@ describe("Mainnet: hardcoded addresses", () => {
   });
 
   it("deterministic deployer", async function () {
-    await expect(
+    expect(
       utils.arrayify(await ethers.provider.getCode(DEPLOYER_CONTRACT)),
     ).to.have.length.greaterThan(0);
   });
@@ -28,14 +28,26 @@ describe("Mainnet: hardcoded addresses", () => {
   it("tokens", async function () {
     const token = (address: string) =>
       new Contract(address, IERC20.abi).connect(ethers.provider);
-    await expect(
-      await token(defaultTokens.usdc[MAINNET_CHAIN_ID]).symbol(),
-    ).to.equal("USDC");
-    await expect(
-      await token(defaultTokens.weth[MAINNET_CHAIN_ID]).symbol(),
-    ).to.equal("WETH");
-    await expect(
-      await token(defaultTokens.gno[MAINNET_CHAIN_ID]).symbol(),
-    ).to.equal("GNO");
+    expect(await token(defaultTokens.usdc[MAINNET_CHAIN_ID]).symbol()).to.equal(
+      "USDC",
+    );
+    expect(await token(defaultTokens.weth[MAINNET_CHAIN_ID]).symbol()).to.equal(
+      "WETH",
+    );
+    expect(await token(defaultTokens.gno[MAINNET_CHAIN_ID]).symbol()).to.equal(
+      "GNO",
+    );
+  });
+
+  it("reality module", async function () {
+    const address = realityModule["1"];
+    expect(
+      utils.arrayify(await ethers.provider.getCode(address)),
+    ).to.have.length.greaterThan(0);
+
+    // This function appears in the DAO module and can be used to as a hint that this is the correct address.
+    const abi = ["function getChainId() view returns (uint256)"];
+    const contract = new Contract(address, abi, ethers.provider);
+    expect(await contract.getChainId()).to.equal(1);
   });
 });

--- a/test/proposal.test.ts
+++ b/test/proposal.test.ts
@@ -27,7 +27,7 @@ import {
   deploymentStepsIntoArray,
   generateProposalAsStruct,
   createTxTriggeringBridgedTokenDeployer,
-  groupWithMultisendCallOnly,
+  groupMultipleTransactions,
 } from "../src/ts";
 import { BridgeParameter, Settings } from "../src/ts/lib/common-interfaces";
 import { amountToRelay } from "../src/ts/lib/constants";
@@ -148,7 +148,7 @@ describe("proposal", function () {
       );
 
       const allCreatedProxies = [];
-      for (const step of groupWithMultisendCallOnly(
+      for (const step of groupMultipleTransactions(
         deploymentStepsIntoArray(steps),
         gnosisSafeManager.getDeploymentAddresses().multisendCallOnly,
       )) {


### PR DESCRIPTION
Makes the DAO proposal easier to verify by computing the transaction hash that is shown in the interface.

The same verification procedure will be adopted for generating a proposal that makes COW swappable for vCOW.

### Test Plan

Follow steps in the updated readme to verify the Snapshot proposal.