### PR TITLE
Fix Dependabot yaml indentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
       day: monday
       time: "02:00"
     open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@openzeppelin/contracts"
+    ignore:
+      - dependency-name: "@openzeppelin/contracts"


### PR DESCRIPTION
The indentation of the current dependabot configs is broken (see "failing CI" on main).
This PR fixes this.

Note that surprisingly we still had our weekly dependabot update (e.g. [this](https://github.com/gnosis/cow-token/pull/122)).

### Test Plan

`yq . <.github/dependabot.yml` doesn't return an error:

```json
{
  "version": 2,
  "updates": [
    {
      "package-ecosystem": "npm",
      "directory": "/",
      "schedule": {
        "interval": "weekly",
        "day": "monday",
        "time": "02:00"
      },
      "open-pull-requests-limit": 10,
      "ignore": [
        {
          "dependency-name": "@openzeppelin/contracts"
        }
      ]
    }
  ]
}

```
