### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/cow-token",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "verify": "hardhat verify-contract-code",


### PR DESCRIPTION
Bumps the version to include the latest small changes to the virtual token ABI in the npm package. This new version will be used by the services.

I'll release a new version as soon as the PR is merged.

### Test Plan

I ran `yarn pack` locally and tried to add and import the resulting tarball in another project. The imported code was found.
