### PR TITLE
Add build artifacts from package (and bump to v1.0.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/cow-token",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "verify": "hardhat verify-contract-code",
@@ -22,6 +22,7 @@
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
   "files": [
+    "build/",
     "lib/",
     "src/"
   ],


### PR DESCRIPTION
The build artifacts are currently not part of the NPM package.
It is generally useful to include them so that other projects can build on top of contract artifacts, for example the ABIs.
Also, they are needed in our services repo.

When this PR is merged I'll trigger a release of a new version of the package.

### Test Plan

The tarball from `yarn pack` includes the build folder.